### PR TITLE
chore: Rename domain to use .prison instead of .hmpps

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,10 +5,10 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: change-someones-cell-dev.hmpps.service.justice.gov.uk
+    host: change-someones-cell-dev.prison.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://change-someones-cell-dev.hmpps.service.justice.gov.uk"
+    INGRESS_URL: "https://change-someones-cell-dev.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -5,10 +5,10 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: change-someones-cell-preprod.hmpps.service.justice.gov.uk
+    host: change-someones-cell-preprod.prison.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://change-someones-cell-preprod.hmpps.service.justice.gov.uk"
+    INGRESS_URL: "https://change-someones-cell-preprod.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     MANAGE_USERS_API_URL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -3,10 +3,10 @@
 
 generic-service:
   ingress:
-    host: change-someones-cell.hmpps.service.justice.gov.uk
+    host: change-someones-cell.prison.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://change-someones-cell.hmpps.service.justice.gov.uk"
+    INGRESS_URL: "https://change-someones-cell.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     MANAGE_USERS_API_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"


### PR DESCRIPTION
It's not a probation thing so .prison is more appropriate

[MAP-10]

[MAP-10]: https://dsdmoj.atlassian.net/browse/MAP-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ