### PR TITLE
[MAP-496] Fix typo in common header code

### DIFF
--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -16,7 +16,7 @@
           nonce="{{ cspNonce }}"
           crossorigin="anonymous"></script>
 
-  {% if feComponents.jsInclude %}
+  {% if feComponents.jsIncludes %}
     {% for js in feComponents.jsIncludes %}
       <script src="{{ js }}" nonce="{{ cspNonce }}"></script>
     {% endfor %}


### PR DESCRIPTION
This typo was causing the header not to display correctly

[MAP-496]