### PR TITLE
fix: Use correct link hrefs on menu page

### DIFF
--- a/server/controllers/cellMove/cellMoveHomepage.ts
+++ b/server/controllers/cellMove/cellMoveHomepage.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import config from '../../config'
 
 type WhereaboutsTask = {
   id: string
@@ -14,7 +15,7 @@ const whereaboutsTasks: (prisonName: string) => WhereaboutsTask[] = prisonName =
     id: 'search-for-prisoner',
     heading: 'Search for a prisoner',
     description: 'Change someone’s cell after searching for them using their name or prison number.',
-    href: '/change-someones-cell/prisoner-search',
+    href: '/prisoner-search',
     roles: null,
     enabled: true,
   },
@@ -22,7 +23,7 @@ const whereaboutsTasks: (prisonName: string) => WhereaboutsTask[] = prisonName =
     id: 'view-residential-location',
     heading: 'View residential location',
     description: 'View all prisoners in a residential location. You can view their cell history and change their cell.',
-    href: '/change-someones-cell/view-residential-location',
+    href: '/view-residential-location',
     roles: null,
     enabled: true,
   },
@@ -31,7 +32,7 @@ const whereaboutsTasks: (prisonName: string) => WhereaboutsTask[] = prisonName =
     heading: 'Move someone temporarily out of a cell',
     description:
       'Create a space for another prisoner by moving someone out of a cell temporarily. You will need to allocate a cell to them later.',
-    href: '/change-someones-cell/temporary-move',
+    href: '/temporary-move',
     roles: null,
     enabled: true,
   },
@@ -39,7 +40,7 @@ const whereaboutsTasks: (prisonName: string) => WhereaboutsTask[] = prisonName =
     id: 'view-history',
     heading: 'View 7 day cell move history',
     description: `View all cell moves completed over the last 7 days in ${prisonName}.`,
-    href: '/change-someones-cell/recent-cell-moves',
+    href: '/recent-cell-moves',
     roles: null,
     enabled: true,
   },
@@ -47,7 +48,7 @@ const whereaboutsTasks: (prisonName: string) => WhereaboutsTask[] = prisonName =
     id: 'no-cell-allocated',
     heading: 'No cell allocated',
     description: 'View people who do not currently have a cell allocated having been temporarily moved out of a cell.',
-    href: '/establishment-roll/no-cell-allocated',
+    href: `${config.dpsUrl}/establishment-roll/no-cell-allocated`,
     roles: null,
     enabled: true,
   },


### PR DESCRIPTION
We decided that there shouldn't be a `change-someones-cell` in the URL path. Also the establishment roll card should link to the main DPS app.