### PR TITLE
[MAP-632] Use system client creds for API calls as per latest advice

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -16,6 +16,7 @@ import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import setUpWebSecurity from './middleware/setUpWebSecurity'
 import setUpWebSession from './middleware/setUpWebSession'
 import getFrontendComponents from './middleware/getFeComponents'
+import populateClientToken from './middleware/populateClientToken'
 
 import routes from './routes'
 import type { Services } from './services'
@@ -39,6 +40,7 @@ export default function createApp(services: Services): express.Application {
   app.use(authorisationMiddleware(['ROLE_CELL_MOVE']))
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
+  app.use(populateClientToken())
   app.get('*', getFrontendComponents(services))
   app.use(setupApiRoutes(services))
 

--- a/server/controllers/cellMove/cellMovePrisonerSearch.test.ts
+++ b/server/controllers/cellMove/cellMovePrisonerSearch.test.ts
@@ -27,6 +27,7 @@ describe('Prisoner search', () => {
         responseHeaders: {
           'total-records': 0,
         },
+        systemClientToken: 'system_client_token',
       },
       render: jest.fn(),
       redirect: jest.fn(),
@@ -47,7 +48,7 @@ describe('Prisoner search', () => {
 
       await controller(req, res)
 
-      expect(prisonerCellAllocationService.getInmates).toHaveBeenCalledWith('me', 'MDI', 'Smith', true)
+      expect(prisonerCellAllocationService.getInmates).toHaveBeenCalledWith('system_client_token', 'MDI', 'Smith', true)
     })
 
     it('should render template with correct data when searched', async () => {

--- a/server/controllers/cellMove/cellMovePrisonerSearch.ts
+++ b/server/controllers/cellMove/cellMovePrisonerSearch.ts
@@ -29,7 +29,7 @@ export default ({ prisonerCellAllocationService }: Params) =>
     const currentUserCaseLoad = activeCaseLoad && activeCaseLoad.caseLoadId
 
     const prisoners = await prisonerCellAllocationService.getInmates(
-      req.user.username,
+      res.locals.systemClientToken,
       currentUserCaseLoad,
       keywords,
       true,

--- a/server/controllers/images.ts
+++ b/server/controllers/images.ts
@@ -12,7 +12,7 @@ export const imageFactory = (prisonerDetailsService: PrisonerDetailsService) => 
       res.redirect(placeHolderImagePath)
     } else {
       prisonerDetailsService
-        .getImage(res.locals.user.token, imageId)
+        .getImage(res.locals.systemClientToken, imageId)
         .then(data => {
           res.type('image/jpeg')
           data.pipe(res)
@@ -37,7 +37,7 @@ export const imageFactory = (prisonerDetailsService: PrisonerDetailsService) => 
       res.redirect(placeHolderImagePath)
     } else {
       prisonerDetailsService
-        .getPrisonerImage(res.locals.user.token, offenderNo, fullSizeImage)
+        .getPrisonerImage(res.locals.systemClientToken, offenderNo, fullSizeImage)
         .then(data => {
           res.set('Cache-control', 'private, max-age=86400')
           res.removeHeader('pragma')

--- a/server/middleware/getFeComponents.ts
+++ b/server/middleware/getFeComponents.ts
@@ -5,14 +5,17 @@ import { Services } from '../services'
 import config from '../config'
 
 export default function getFrontendComponents({ feComponentsService }: Services): RequestHandler {
-  return async (req, res, next) => {
+  return async (_req, res, next) => {
     if (!config.apis.frontendComponents.enabled) {
       res.locals.feComponents = {}
       return next()
     }
 
     try {
-      const { header, footer } = await feComponentsService.getComponents(['header', 'footer'], res.locals.user.token)
+      const { header, footer } = await feComponentsService.getComponents(
+        ['header', 'footer'],
+        res.locals.systemClientToken,
+      )
 
       res.locals.feComponents = {
         header: header.html,

--- a/server/middleware/populateClientToken.ts
+++ b/server/middleware/populateClientToken.ts
@@ -1,0 +1,23 @@
+import { RequestHandler } from 'express'
+import logger from '../../logger'
+import { dataAccess } from '../data'
+
+export default function populateClientToken(): RequestHandler {
+  return async (_req, res, next) => {
+    try {
+      const { hmppsAuthClient } = dataAccess()
+      if (res.locals.user) {
+        const clientToken = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
+        if (clientToken) {
+          res.locals.systemClientToken = clientToken
+        } else {
+          logger.info('No client token available')
+        }
+      }
+      next()
+    } catch (error) {
+      logger.error(error, `Failed to retrieve client token for: ${res.locals.user && res.locals.user.username}`)
+      next(error)
+    }
+  }
+}

--- a/server/services/prisonerCellAllocationService.ts
+++ b/server/services/prisonerCellAllocationService.ts
@@ -7,13 +7,7 @@ export default class PrisonerCellAllocationService {
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
 
-  async getInmates(
-    username: string,
-    locationId: string,
-    keywords: string,
-    returnAlerts?: boolean,
-  ): Promise<Offender[]> {
-    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+  async getInmates(token: string, locationId: string, keywords: string, returnAlerts?: boolean): Promise<Offender[]> {
     return await this.prisonApiClient.getInmates(token, locationId, keywords, returnAlerts)
   }
 }


### PR DESCRIPTION
The original DPS app uses user creds for some API calls and system client creds for others, but the latest advice is to use system client creds for everything.

[MAP-632]

[MAP-632]: https://dsdmoj.atlassian.net/browse/MAP-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ