### PR TITLE
Enable skipped integration tests

### DIFF
--- a/integration_tests/e2e/searchForCell.cy.ts
+++ b/integration_tests/e2e/searchForCell.cy.ts
@@ -249,7 +249,7 @@ context('A user can search for a cell', () => {
       })
     })
 
-    context.skip('When the user clicked back from the select cell page', () => {
+    context('When the user clicked back from the select cell page', () => {
       const response = [
         {
           attributes: [

--- a/integration_tests/e2e/selectCell.cy.ts
+++ b/integration_tests/e2e/selectCell.cy.ts
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import SelectCellPage from '../pages/selectCellPage'
+import ConsiderRisksPage from '../pages/considerRisksPage'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const offenderFullDetails = require('../mockApis/responses/offenderFullDetails.json')
@@ -292,7 +293,7 @@ context('A user can select a cell', () => {
         })
       })
 
-      context.skip('When the user clicked back from the consider risks page', () => {
+      context('When the user clicked back from the consider risks page', () => {
         beforeEach(() => {
           cy.task('stubOffenderFullDetails', offenderFullDetails)
           cy.task('stubOffenderNonAssociationsLegacy', {})
@@ -313,7 +314,7 @@ context('A user can select a cell', () => {
             nonAssociations: [],
           })
 
-          // ConsiderRisksPage.goTo(offenderNo, 1)
+          ConsiderRisksPage.goTo(offenderNo, 1)
           cy.contains('Back').click()
           cy.contains('Select an available cell')
         })


### PR DESCRIPTION
These tests were skipped because the pages didn't exist yet, but now they do.