### PR TITLE
[MAP-683] Get active caseload from frontend components API metadata if possible

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -41,9 +41,9 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpAuthentication())
   app.use(authorisationMiddleware(['ROLE_CELL_MOVE']))
   app.use(setUpCsrf())
+  app.get('*', getFrontendComponents(services))
   app.use(setUpCurrentUser(services))
   app.use(populateClientToken())
-  app.get('*', getFrontendComponents(services))
   app.use(setupApiRoutes(services))
 
   app.use(routes(services))

--- a/server/data/feComponentsClient.ts
+++ b/server/data/feComponentsClient.ts
@@ -9,19 +9,43 @@ export interface Component {
 
 export type AvailableComponent = 'header' | 'footer'
 
+type CaseLoad = {
+  caseLoadId: string
+  description: string
+  type: string
+  caseloadFunction: string
+  currentlyActive: boolean
+}
+
+type Service = {
+  description: string
+  heading: string
+  href: string
+  id: string
+}
+
+export interface FeComponentsMeta {
+  activeCaseLoad: CaseLoad
+  caseLoads: CaseLoad[]
+  services: Service[]
+}
+
+export interface FeComponentsResponse {
+  header?: Component
+  footer?: Component
+  meta: FeComponentsMeta
+}
+
 export default class FeComponentsClient {
   private static restClient(token: string): RestClient {
     return new RestClient('HMPPS Components Client', config.apis.frontendComponents, token)
   }
 
-  getComponents<T extends AvailableComponent[]>(
-    components: T,
-    userToken: string,
-  ): Promise<Record<T[number], Component>> {
-    return FeComponentsClient.restClient(userToken).get({
+  getComponents<T extends AvailableComponent[]>(components: T, userToken: string): Promise<FeComponentsResponse> {
+    return FeComponentsClient.restClient(userToken).get<FeComponentsResponse>({
       path: `/components`,
       query: `component=${components.join('&component=')}`,
       headers: { 'x-user-token': userToken },
-    }) as Promise<Record<T[number], Component>>
+    })
   }
 }

--- a/server/middleware/getFeComponents.ts
+++ b/server/middleware/getFeComponents.ts
@@ -12,13 +12,17 @@ export default function getFrontendComponents({ feComponentsService }: Services)
     }
 
     try {
-      const { header, footer } = await feComponentsService.getComponents(['header', 'footer'], res.locals.user.token)
+      const { header, footer, meta } = await feComponentsService.getComponents(
+        ['header', 'footer'],
+        res.locals.user.token,
+      )
 
       res.locals.feComponents = {
         header: header.html,
         footer: footer.html,
         cssIncludes: [...header.css, ...footer.css],
         jsIncludes: [...header.javascript, ...footer.javascript],
+        meta,
       }
       return next()
     } catch (error) {

--- a/server/services/feComponentsService.test.ts
+++ b/server/services/feComponentsService.test.ts
@@ -1,5 +1,5 @@
 import FeComponentsService from './feComponentsService'
-import FeComponentsClient, { AvailableComponent, Component } from '../data/feComponentsClient'
+import FeComponentsClient, { FeComponentsResponse } from '../data/feComponentsClient'
 
 jest.mock('../data/feComponentsClient')
 
@@ -16,7 +16,15 @@ describe('Components service', () => {
     })
 
     it('Retrieves and returns requested component', async () => {
-      const componentValue: Record<AvailableComponent, Component> = {
+      const caseLoad = {
+        caseLoadId: 'LEI',
+        description: 'Leeds (HMP)',
+        type: 'INST',
+        caseloadFunction: 'GENERAL',
+        currentlyActive: true,
+      }
+
+      const componentValue: FeComponentsResponse = {
         header: {
           html: '<header></header>',
           css: [],
@@ -26,6 +34,11 @@ describe('Components service', () => {
           html: '<footer></footer>',
           css: [],
           javascript: [],
+        },
+        meta: {
+          activeCaseLoad: caseLoad,
+          caseLoads: [caseLoad],
+          services: [],
         },
       }
 

--- a/server/services/feComponentsService.ts
+++ b/server/services/feComponentsService.ts
@@ -1,12 +1,9 @@
-import FeComponentsClient, { AvailableComponent, Component } from '../data/feComponentsClient'
+import FeComponentsClient, { AvailableComponent } from '../data/feComponentsClient'
 
 export default class FeComponentsService {
   constructor(private readonly feComponentsClient: FeComponentsClient) {}
 
-  async getComponents<T extends AvailableComponent[]>(
-    components: T,
-    token: string,
-  ): Promise<Record<T[number], Component>> {
+  async getComponents<T extends AvailableComponent[]>(components: T, token: string) {
     return this.feComponentsClient.getComponents(components, token)
   }
 }


### PR DESCRIPTION
This makes sure that the caseload shown in the header matches the active caseload that the app is aware of!

See discussion:
https://mojdt.slack.com/archives/C69NWE339/p1706794247306949?thread_ts=1706793461.544379&cid=C69NWE339

[MAP-683]

[MAP-683]: https://dsdmoj.atlassian.net/browse/MAP-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ