### PR TITLE
fix: Use correct back links even after validation errors

### DIFF
--- a/integration_tests/e2e/considerRisks.cy.ts
+++ b/integration_tests/e2e/considerRisks.cy.ts
@@ -497,6 +497,15 @@ context('A user can see conflicts in cell', () => {
         cy.contains('Back').click()
         cy.contains('Select an available cell')
       })
+
+      it('should still have the correct back link when validation errors are shown', () => {
+        stubPrisonDetails()
+        const page = ConsiderRisksPage.goTo(offenderNo, 1)
+        page.form().submitButton().click()
+        page.errorSummary().contains('Select yes if you are sure you want to select the cell')
+        cy.contains('Back').click()
+        cy.contains('Select an available cell')
+      })
     })
   })
 })

--- a/integration_tests/e2e/receptionConsiderRisks.cy.ts
+++ b/integration_tests/e2e/receptionConsiderRisks.cy.ts
@@ -320,4 +320,19 @@ context('Reception full journey', () => {
         expect(href).to.equal('http://localhost:3101/prisoner/G3878UK/location-details')
       })
   })
+
+  context('when validation errors are shown', () => {
+    it('should still have the correct back links', () => {
+      const page = considerRisksPage.goTo(offenderNo)
+
+      page.form().submitButton().click()
+      page.errorSummary().should('contain', 'There is a problem').and('contain', 'Select yes or no')
+
+      cy.get('.govuk-back-link')
+        .invoke('attr', 'href')
+        .then(href => {
+          expect(href).to.equal('http://localhost:3101/prisoner/G3878UK/location-details')
+        })
+    })
+  })
 })

--- a/integration_tests/pages/receptionConfirmMovePage.ts
+++ b/integration_tests/pages/receptionConfirmMovePage.ts
@@ -20,14 +20,14 @@ const receptionConfirmMovePage: () => any = () =>
         .get('[data-test="cancel-link"]')
         .invoke('attr', 'href')
         .then(href => {
-          expect(href).to.equal('/prisoner/G3878UK/location-details')
+          expect(href).to.equal('http://localhost:3101/prisoner/G3878UK/location-details')
         }),
     locationDetailsLink: () =>
       cy
         .get('[data-test="location-details-link"]')
         .invoke('attr', 'href')
         .then(href => {
-          expect(href).to.equal('/prisoner/G3878UK/location-details')
+          expect(href).to.equal('http://localhost:3101/prisoner/G3878UK/location-details')
         }),
   })
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -8,6 +8,7 @@ declare module 'express-session' {
   interface SessionData {
     returnTo: string
     nowInMinutes: number
+    referrerUrl?: string
   }
 }
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -23,6 +23,7 @@ import routes from './routes'
 import type { Services } from './services'
 import setupApiRoutes from './setupApiRoutes'
 import returnUrl from './middleware/returnUrl'
+import referrerUrl from './middleware/referrerUrl'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -46,6 +47,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpCurrentUser(services))
   app.use(populateClientToken())
   app.use(returnUrl())
+  app.use(referrerUrl())
   app.use(setupApiRoutes(services))
 
   app.use(routes(services))

--- a/server/controllers/cellMove/cellMoveConfirmation.test.ts
+++ b/server/controllers/cellMove/cellMoveConfirmation.test.ts
@@ -1,6 +1,7 @@
 import cellMoveConfirmation from './cellMoveConfirmation'
 import LocationService from '../../services/locationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
+import config from '../../config'
 
 jest.mock('../../services/locationService')
 jest.mock('../../services/prisonerDetailsService')
@@ -57,6 +58,6 @@ describe('Cell move confirmation', () => {
     await expect(controller(req, res)).rejects.toThrow(error)
 
     expect(res.locals.redirectUrl).toBe(`/prisoner/${offenderNo}/cell-move/search-for-cell`)
-    expect(res.locals.homeUrl).toBe(`/prisoner/${offenderNo}`)
+    expect(res.locals.homeUrl).toBe(`${config.prisonerProfileUrl}/prisoner/${offenderNo}`)
   })
 })

--- a/server/controllers/cellMove/cellMoveConfirmation.ts
+++ b/server/controllers/cellMove/cellMoveConfirmation.ts
@@ -1,3 +1,4 @@
+import config from '../../config'
 import LocationService from '../../services/locationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import { formatName } from '../../utils'
@@ -22,7 +23,7 @@ export default ({ locationService, prisonerDetailsService }: Params) =>
       })
     } catch (error) {
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/search-for-cell`
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }

--- a/server/controllers/cellMove/cellNotAvailable.ts
+++ b/server/controllers/cellMove/cellNotAvailable.ts
@@ -1,3 +1,5 @@
+import config from '../../config'
+
 export default () => async (req, res) => {
   const { offenderNo } = req.params
   const { cellDescription } = req.query
@@ -11,7 +13,7 @@ export default () => async (req, res) => {
     })
   } catch (error) {
     res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/search-for-cell`
-    res.locals.homeUrl = `/prisoner/${offenderNo}`
+    res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
     throw error
   }
 }

--- a/server/controllers/cellMove/confirmCellMove.test.ts
+++ b/server/controllers/cellMove/confirmCellMove.test.ts
@@ -4,6 +4,7 @@ import AnalyticsService from '../../services/analyticsService'
 import LocationService from '../../services/locationService'
 import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
+import config from '../../config'
 
 jest.mock('../../services/analyticsService')
 jest.mock('../../services/locationService')
@@ -20,7 +21,7 @@ describe('Change cell play back details', () => {
 
   const systemClientToken = 'system_token'
 
-  const req = {
+  const req: any = {
     originalUrl: 'http://localhost',
     params: { offenderNo: 'A12345' },
     query: {},
@@ -313,7 +314,7 @@ describe('Change cell play back details', () => {
     `(
       'The back link button content is $backLinkText when the referer is $referer',
       async ({ referer, backLinkText }) => {
-        req.headers = { referer }
+        req.session = { referrerUrl: referer }
 
         await controller.index(req, res)
 
@@ -440,7 +441,7 @@ describe('Change cell play back details', () => {
       await expect(controller.post(req, res)).rejects.toThrowError(error)
 
       expect(res.locals.redirectUrl).toBe(`/prisoner/${offenderNo}/cell-move/select-cell`)
-      expect(res.locals.homeUrl).toBe(`/prisoner/${offenderNo}`)
+      expect(res.locals.homeUrl).toBe(`${config.prisonerProfileUrl}/prisoner/${offenderNo}`)
     })
 
     it('should raise an analytics event', async () => {

--- a/server/controllers/cellMove/confirmCellMove.ts
+++ b/server/controllers/cellMove/confirmCellMove.ts
@@ -1,4 +1,5 @@
 import logger from '../../../logger'
+import config from '../../config'
 import AnalyticsService from '../../services/analyticsService'
 import LocationService from '../../services/locationService'
 import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
@@ -57,7 +58,7 @@ export default ({
       ? undefined
       : await cellMoveReasons(systemClientToken, prisonerCellAllocationService, reason)
 
-    const { backLink, backLinkText } = getConfirmBackLinkData(req.headers.referer, offenderNo)
+    const { backLink, backLinkText } = getConfirmBackLinkData(req.session?.referrerUrl, offenderNo)
     return res.render('cellMove/confirmCellMove.njk', {
       showWarning: !isCellSwap,
       offenderNo,
@@ -187,7 +188,7 @@ export default ({
     } catch (error) {
       res.locals.logMessagev = `Failed to make cell move to ${cellId}`
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/select-cell`
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }

--- a/server/controllers/cellMove/confirmReceptionMove.test.ts
+++ b/server/controllers/cellMove/confirmReceptionMove.test.ts
@@ -3,6 +3,7 @@ import logger from '../../../logger'
 import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import { OffenderCell, ReferenceCode } from '../../data/prisonApiClient'
+import config from '../../config'
 
 jest.mock('../../services/prisonerCellAllocationService')
 jest.mock('../../services/prisonerDetailsService')
@@ -18,13 +19,13 @@ describe('Confirm reception move', () => {
 
   const systemClientToken = 'system_token'
 
-  const req = {
+  const req: any = {
     originalUrl: 'http://localhost',
     params: { offenderNo: 'A12345' },
     query: {},
-    headers: { referer: '' },
     flash: jest.fn(),
     body: {},
+    session: {},
   }
   const res = {
     locals: {
@@ -90,7 +91,7 @@ describe('Confirm reception move', () => {
     })
 
     it('Should set backUrl to the previous page', async () => {
-      req.headers.referer = '/prisoner/A12345/reception-move/consider-risks-reception'
+      req.session.referrerUrl = '/prisoner/A12345/reception-move/consider-risks-reception'
       await controller.view(req, res)
 
       expect(res.render).toHaveBeenCalledWith(
@@ -99,7 +100,7 @@ describe('Confirm reception move', () => {
       )
     })
     it('Should set backUrl to null', async () => {
-      req.headers.referer = null
+      req.session.referrerUrl = null
       await controller.view(req, res)
       expect(res.render).toHaveBeenCalledWith(
         'receptionMove/confirmReceptionMove.njk',
@@ -174,12 +175,12 @@ describe('Confirm reception move', () => {
       )
     })
     it('should render complete set of render data', async () => {
-      req.headers.referer = '/prisoner/A12345/reception-move/consider-risks-reception'
+      req.session.referrerUrl = '/prisoner/A12345/reception-move/consider-risks-reception'
       await controller.view(req, res)
 
       expect(res.render).toHaveBeenCalledWith('receptionMove/confirmReceptionMove.njk', {
         backUrl: '/prisoner/A12345/reception-move/consider-risks-reception',
-        cancelLinkHref: '/prisoner/A12345/location-details',
+        cancelLinkHref: `${config.prisonerProfileUrl}/prisoner/A12345/location-details`,
         errors: undefined,
         formValues: { comment: undefined },
         offenderName: 'Bob Doe',

--- a/server/controllers/cellMove/confirmReceptionMove.ts
+++ b/server/controllers/cellMove/confirmReceptionMove.ts
@@ -3,6 +3,7 @@ import { properCaseName } from '../../utils'
 import logger from '../../../logger'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
+import config from '../../config'
 
 const sortOnListSeq = (a, b) => a.listSeq - b.listSeq
 
@@ -53,14 +54,14 @@ export default ({ prisonerCellAllocationService, prisonerDetailsService }: Param
 
     let backUrl = `/prisoner/${offenderNo}/reception-move/consider-risks-reception`
 
-    if (!req.headers.referer) {
+    if (!req.session?.referrerUrl) {
       backUrl = null
     }
 
     const formValues = req.flash('formValues') as any[]
     const { reason, comment } = (formValues && formValues[0]) || {}
     const receptionMoveReasonRadioValues = await receptionMoveReasons(systemClientToken, reason)
-    const cancelLinkHref = `/prisoner/${offenderNo}/location-details`
+    const cancelLinkHref = `${config.prisonerProfileUrl}/prisoner/${offenderNo}/location-details`
 
     const data = {
       offenderName: `${properCaseName(firstName)} ${properCaseName(lastName)}`,

--- a/server/controllers/cellMove/considerRisks.test.ts
+++ b/server/controllers/cellMove/considerRisks.test.ts
@@ -6,6 +6,7 @@ import NonAssociationsService from '../../services/nonAssociationsService'
 import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import { OffenderDetails } from '../../data/prisonApiClient'
+import config from '../../config'
 
 Reflect.deleteProperty(process.env, 'APPINSIGHTS_INSTRUMENTATIONKEY')
 
@@ -621,7 +622,7 @@ describe('move validation', () => {
         'Occupant Two is CSRA Standard.',
       ],
       prisonerNameForBreadcrumb: 'User, Test',
-      profileUrl: '/prisoner/ABC123',
+      profileUrl: `${config.prisonerProfileUrl}/prisoner/ABC123`,
       selectCellUrl: '/prisoner/ABC123/cell-move/select-cell',
       showOffendersNamesWithCsra: true,
       showRisks: true,
@@ -885,6 +886,6 @@ describe('move validation', () => {
 
     await expect(controller.post(req, res)).rejects.toThrow(error)
     expect(res.locals.redirectUrl).toBe(`/prisoner/${offenderNo}/cell-move/select-cell`)
-    expect(res.locals.homeUrl).toBe(`/prisoner/${offenderNo}`)
+    expect(res.locals.homeUrl).toBe(`${config.prisonerProfileUrl}/prisoner/${offenderNo}`)
   })
 })

--- a/server/controllers/cellMove/considerRisks.ts
+++ b/server/controllers/cellMove/considerRisks.ts
@@ -178,14 +178,12 @@ export default ({
         return res.redirect(`/prisoner/${offenderNo}/cell-move/confirm-cell-move?cellId=${cellId}`)
       }
 
-      const profileUrl = `/prisoner/${offenderNo}`
-
       return res.render('cellMove/considerRisks.njk', {
         offenderNo,
         currentOffenderName,
         prisonerNameForBreadcrumb: putLastNameFirst(currentOffenderDetails.firstName, currentOffenderDetails.lastName),
-        profileUrl,
-        selectCellUrl: `${profileUrl}/cell-move/select-cell`,
+        profileUrl: `${config.prisonerProfileUrl}/prisoner/${offenderNo}`,
+        selectCellUrl: `/prisoner/${offenderNo}/cell-move/select-cell`,
         showOffendersNamesWithCsra,
         confirmationQuestionLabel: hasOccupants
           ? `Are you sure you want to move ${currentOffenderName} into a cell with ${createStringFromList(
@@ -214,7 +212,7 @@ export default ({
           currentOccupantsWithFormattedActiveAlerts.length > 0 ||
           categoryWarning,
         errors,
-        backUrl: `${profileUrl}/cell-move/select-cell`,
+        backUrl: `/prisoner/${offenderNo}/cell-move/select-cell`,
       })
     } catch (error) {
       res.locals.redirectUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}/location-details`
@@ -288,7 +286,7 @@ export default ({
       return res.redirect(redirectUrl)
     } catch (error) {
       res.locals.redirectUrl = redirectUrl
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }

--- a/server/controllers/cellMove/considerRisksReception.test.ts
+++ b/server/controllers/cellMove/considerRisksReception.test.ts
@@ -4,6 +4,7 @@ import NonAssociationsService from '../../services/nonAssociationsService'
 import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import { Assessment } from '../../data/prisonApiClient'
+import config from '../../config'
 
 jest.mock('../../services/nonAssociationsService')
 jest.mock('../../services/prisonerCellAllocationService')
@@ -226,7 +227,7 @@ describe('Consider risks reception', () => {
       expect(res.render).toHaveBeenCalledWith(
         'receptionMove/considerRisksReception.njk',
         expect.objectContaining({
-          backUrl: '/prisoners/A12345/location-details',
+          backUrl: `${config.prisonerProfileUrl}/prisoner/A12345/location-details`,
           csraDetailsUrl: '/prisoner/A12345/cell-move/cell-sharing-risk-assessment-details',
           displayLinkToPrisonersMostRecentCsra: 'comment 1',
           nonAssociationLink: '/prisoner/A12345/cell-move/non-associations',
@@ -254,14 +255,16 @@ describe('Consider risks reception', () => {
     it('should redirect to previous page', async () => {
       req.body = { considerRisksReception: 'no' }
       await controller.submit(req, res)
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoner/${someOffenderNumber}/location-details`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `${config.prisonerProfileUrl}/prisoner/${someOffenderNumber}/location-details`,
+      )
     })
 
     it('should throw error when call to upstream api rejects', async () => {
       const error = new Error('Network error')
       prisonerDetailsService.getCsraAssessments.mockRejectedValue(error)
       await expect(controller.view(req, res)).rejects.toThrow(error)
-      expect(res.locals.homeUrl).toBe(`/prisoner/${someOffenderNumber}`)
+      expect(res.locals.homeUrl).toBe(`${config.prisonerProfileUrl}/prisoner/${someOffenderNumber}`)
     })
   })
 })

--- a/server/controllers/cellMove/considerRisksReception.ts
+++ b/server/controllers/cellMove/considerRisksReception.ts
@@ -6,6 +6,7 @@ import { logError } from '../../logError'
 import NonAssociationsService from '../../services/nonAssociationsService'
 import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
+import config from '../../config'
 
 type Params = {
   nonAssociationsService: NonAssociationsService
@@ -144,7 +145,7 @@ export default ({ nonAssociationsService, prisonerCellAllocationService, prisone
         csraDetailsUrl: `/prisoner/${offenderNo}/cell-move/cell-sharing-risk-assessment-details`,
         displayLinkToPrisonersMostRecentCsra,
         convertedCsra: translateCsra(prisonerDetails.csraClassificationCode),
-        backUrl: `/prisoners/${offenderNo}/location-details`,
+        backUrl: `${config.prisonerProfileUrl}/prisoner/${offenderNo}/location-details`,
         hasNonAssociations: nonAssociationsInEstablishment?.length > 0,
         nonAssociationsRows,
         offendersInReception: otherOffenders,
@@ -153,7 +154,7 @@ export default ({ nonAssociationsService, prisonerCellAllocationService, prisone
       })
     } catch (error) {
       logError(req.originalUrl, error, 'error getting consider-risks-reception')
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }
@@ -172,7 +173,7 @@ export default ({ nonAssociationsService, prisonerCellAllocationService, prisone
     if (considerRisksReception === 'yes') {
       return res.redirect(`/prisoner/${offenderNo}/reception-move/confirm-reception-move`)
     }
-    return res.redirect(`/prisoner/${offenderNo}/location-details`)
+    return res.redirect(`${config.prisonerProfileUrl}/prisoner/${offenderNo}/location-details`)
   }
 
   return { view, submit }

--- a/server/controllers/cellMove/receptionFull.test.ts
+++ b/server/controllers/cellMove/receptionFull.test.ts
@@ -43,10 +43,10 @@ describe('Reception full', () => {
     prisonerDetailsService.getDetails.mockResolvedValue(details)
 
     req = {
-      headers: { referer: 'refering-url' },
       params: {
         offenderNo: someOffenderNumber,
       },
+      session: { referrerUrl: 'refering-url' },
     }
 
     res = {

--- a/server/controllers/cellMove/receptionFull.ts
+++ b/server/controllers/cellMove/receptionFull.ts
@@ -15,7 +15,7 @@ export default ({ prisonerDetailsService }: Params) => {
     const data = {
       offenderName: formatName(firstName, lastName),
       offenderNo,
-      backUrl: req.headers.referer,
+      backUrl: req.session?.referrerUrl,
     }
 
     return res.render('receptionMove/receptionFull.njk', data)

--- a/server/controllers/cellMove/searchForCell.test.ts
+++ b/server/controllers/cellMove/searchForCell.test.ts
@@ -377,8 +377,8 @@ describe('select location', () => {
         await controller(
           {
             ...req,
-            headers: {
-              referer: 'http://dps/prisoner/G0637UO/cell-move/select-cell',
+            session: {
+              referrerUrl: 'http://dps/prisoner/G0637UO/cell-move/select-cell',
             },
           },
           res,
@@ -396,8 +396,8 @@ describe('select location', () => {
         await controller(
           {
             ...req,
-            headers: {
-              referer: 'http://dps/prisoner/G0637UO/cell-move/confirm-cell-move',
+            session: {
+              referrerUrl: 'http://dps/prisoner/G0637UO/cell-move/confirm-cell-move',
             },
           },
           res,
@@ -415,8 +415,8 @@ describe('select location', () => {
         await controller(
           {
             ...req,
-            headers: {
-              referer: '/dps/some/other/page',
+            session: {
+              referrerUrl: '/dps/some/other/page',
             },
           },
           res,

--- a/server/controllers/cellMove/searchForCell.ts
+++ b/server/controllers/cellMove/searchForCell.ts
@@ -56,7 +56,7 @@ export default ({ locationService, nonAssociationsService, prisonerDetailsServic
         },
       }
 
-      let backUrl = req.headers.referer
+      let backUrl = req.session?.referrerUrl
       // If the referrer is a later page in the journey (i.e. the user already clicked back to get here), make the back
       // link point to the prisoner search page instead
       if (!backUrl || backUrl.endsWith('/cell-move/select-cell') || backUrl.endsWith('/cell-move/confirm-cell-move')) {

--- a/server/controllers/cellMove/selectCell.ts
+++ b/server/controllers/cellMove/selectCell.ts
@@ -15,6 +15,7 @@ import NonAssociationsService from '../../services/nonAssociationsService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import LocationService from '../../services/locationService'
 import { OffenderNonAssociationLegacy } from '../../data/nonAssociationsApiClient'
+import config from '../../config'
 
 const defaultSubLocationsValue = { text: 'Select area in residential unit', value: '' }
 const noAreasSelectedDropDownValue = { text: 'No areas to select', value: '' }
@@ -301,7 +302,7 @@ export default ({
       })
     } catch (error) {
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/search-for-cell`
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }

--- a/server/controllers/cellMove/spaceCreated.test.ts
+++ b/server/controllers/cellMove/spaceCreated.test.ts
@@ -1,6 +1,7 @@
 import spaceCreatedController from './spaceCreated'
 import { OffenderDetails } from '../../data/prisonApiClient'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
+import config from '../../config'
 
 jest.mock('../../services/prisonerDetailsService')
 
@@ -81,7 +82,7 @@ describe('Space created', () => {
 
       await expect(controller(req, res)).rejects.toThrowError(error)
       expect(res.locals.redirectUrl).toBe(`/prisoner/${offenderNo}/cell-move/search-for-cell`)
-      expect(res.locals.homeUrl).toBe(`/prisoner/${offenderNo}`)
+      expect(res.locals.homeUrl).toBe(`${config.prisonerProfileUrl}/prisoner/${offenderNo}`)
     })
   })
 })

--- a/server/controllers/cellMove/spaceCreated.ts
+++ b/server/controllers/cellMove/spaceCreated.ts
@@ -1,3 +1,4 @@
+import config from '../../config'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import { properCaseName } from '../../utils'
 
@@ -20,7 +21,7 @@ export default ({ prisonerDetailsService }: Params) =>
       })
     } catch (error) {
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/search-for-cell`
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }

--- a/server/controllers/cellMove/viewCellSharingAssessmentDetails.ts
+++ b/server/controllers/cellMove/viewCellSharingAssessmentDetails.ts
@@ -3,6 +3,7 @@ import { putLastNameFirst, hasLength } from '../../utils'
 import { getBackLinkData, translateCsra } from './cellMoveUtils'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import LocationService from '../../services/locationService'
+import config from '../../config'
 
 type Params = {
   locationService: LocationService
@@ -41,11 +42,11 @@ export default ({ locationService, prisonerDetailsService }: Params) =>
             moment(mostRecentAssessment.assessmentDate, 'YYYY-MM-DD').format('D MMMM YYYY')) ||
           'Not entered',
         comment: (mostRecentAssessment && mostRecentAssessment.assessmentComment) || 'Not entered',
-        ...getBackLinkData(req.headers.referer, offenderNo),
+        ...getBackLinkData(req.session?.referrerUrl, offenderNo),
       })
     } catch (error) {
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/search-for-cell`
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }

--- a/server/controllers/cellMove/viewCellSharingRiskAssessment.test.ts
+++ b/server/controllers/cellMove/viewCellSharingRiskAssessment.test.ts
@@ -1,6 +1,7 @@
 import viewCellSharingRiskAssessmentDetails from './viewCellSharingAssessmentDetails'
 import LocationService from '../../services/locationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
+import config from '../../config'
 
 Reflect.deleteProperty(process.env, 'APPINSIGHTS_INSTRUMENTATIONKEY')
 
@@ -110,7 +111,7 @@ describe('view CSRA details', () => {
     await expect(controller(req, res)).rejects.toThrowError(error)
 
     expect(res.locals.redirectUrl).toBe('/prisoner/ABC123/cell-move/search-for-cell')
-    expect(res.locals.homeUrl).toBe('/prisoner/ABC123')
+    expect(res.locals.homeUrl).toBe(`${config.prisonerProfileUrl}/prisoner/ABC123`)
   })
 
   it('populates the data correctly', async () => {
@@ -132,7 +133,7 @@ describe('view CSRA details', () => {
   })
 
   it('sets the back link and text correctly when referer data is present', async () => {
-    req = { ...req, headers: { referer: `/prisoner/${offenderNo}/cell-move/select-cell` } }
+    req = { ...req, session: { referrerUrl: `/prisoner/${offenderNo}/cell-move/select-cell` } }
     await controller(req, res)
 
     expect(res.render).toHaveBeenCalledWith(

--- a/server/controllers/cellMove/viewNonAssociations.test.ts
+++ b/server/controllers/cellMove/viewNonAssociations.test.ts
@@ -2,6 +2,7 @@ import moment from 'moment'
 import viewNonAssociations from './viewNonAssociations'
 import NonAssociationsService from '../../services/nonAssociationsService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
+import config from '../../config'
 
 Reflect.deleteProperty(process.env, 'APPINSIGHTS_INSTRUMENTATIONKEY')
 
@@ -162,7 +163,7 @@ describe('view non associations', () => {
 
     await expect(controller(req, res)).rejects.toThrow(error)
 
-    expect(res.locals.homeUrl).toBe('/prisoner/ABC123')
+    expect(res.locals.homeUrl).toBe(`${config.prisonerProfileUrl}/prisoner/ABC123`)
   })
 
   it('populates the data correctly', async () => {
@@ -206,7 +207,7 @@ describe('view non associations', () => {
   })
 
   it('sets the back link and text correctly when referer data is present', async () => {
-    req = { ...req, headers: { referer: `/prisoner/${offenderNo}/cell-move/select-cell` } }
+    req = { ...req, session: { referrerUrl: `/prisoner/${offenderNo}/cell-move/select-cell` } }
     await controller(req, res)
 
     expect(res.render).toHaveBeenCalledWith(

--- a/server/controllers/cellMove/viewNonAssociations.ts
+++ b/server/controllers/cellMove/viewNonAssociations.ts
@@ -3,6 +3,7 @@ import { putLastNameFirst, formatName } from '../../utils'
 import { getBackLinkData, getNonAssociationsInEstablishment } from './cellMoveUtils'
 import NonAssociationsService from '../../services/nonAssociationsService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
+import config from '../../config'
 
 type Params = {
   nonAssociationsService: NonAssociationsService
@@ -55,10 +56,10 @@ export default ({ prisonerDetailsService, nonAssociationsService }: Params) =>
         prisonerName: formatName(firstName, lastName),
         searchForCellLink: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
         offenderNo,
-        ...getBackLinkData(req.headers.referer, offenderNo),
+        ...getBackLinkData(req.session?.referrerUrl, offenderNo),
       })
     } catch (error) {
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }

--- a/server/controllers/cellMove/viewOffenderDetails.test.ts
+++ b/server/controllers/cellMove/viewOffenderDetails.test.ts
@@ -1,3 +1,4 @@
+import config from '../../config'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import viewOffenderDetails from './viewOffenderDetails'
 
@@ -82,7 +83,7 @@ describe('view offender details', () => {
     await expect(controller(req, res)).rejects.toThrowError(error)
 
     expect(res.locals.redirectUrl).toBe('/prisoner/ABC123/cell-move/search-for-cell')
-    expect(res.locals.homeUrl).toBe('/prisoner/ABC123')
+    expect(res.locals.homeUrl).toBe(`${config.prisonerProfileUrl}/prisoner/ABC123`)
   })
 
   it('populates the data correctly when all present', async () => {
@@ -156,7 +157,7 @@ describe('view offender details', () => {
   })
 
   it('sets the back link and text correctly when referer data is present', async () => {
-    req = { ...req, headers: { referer: `/prisoner/${offenderNo}/cell-move/select-cell` } }
+    req = { ...req, session: { referrerUrl: `/prisoner/${offenderNo}/cell-move/select-cell` } }
     await controller(req, res)
 
     expect(res.render).toHaveBeenCalledWith(

--- a/server/controllers/cellMove/viewOffenderDetails.ts
+++ b/server/controllers/cellMove/viewOffenderDetails.ts
@@ -37,12 +37,12 @@ export default ({ prisonerDetailsService }: Params) =>
         sexualOrientation: getValueByType('SEXO', profileInformation, 'resultValue') || 'Not entered',
         smokerOrVaper: getValueByType('SMOKE', profileInformation, 'resultValue') || 'Not entered',
         mainOffence: (mainOffence && mainOffence[0] && mainOffence[0].offenceDescription) || 'Not entered',
-        ...getBackLinkData(req.headers.referer, offenderNo),
+        ...getBackLinkData(req.session?.referrerUrl, offenderNo),
         profileUrl: `${config.prisonerProfileUrl}/prisoner/${offenderNo}`,
       })
     } catch (error) {
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/search-for-cell`
-      res.locals.homeUrl = `/prisoner/${offenderNo}`
+      res.locals.homeUrl = `${config.prisonerProfileUrl}/prisoner/${offenderNo}`
       throw error
     }
   }

--- a/server/middleware/referrerUrl.test.ts
+++ b/server/middleware/referrerUrl.test.ts
@@ -1,0 +1,69 @@
+import referrerUrl from './referrerUrl'
+
+describe('Referrer URL', () => {
+  const res = {}
+  let req
+  let next
+  let controller
+
+  beforeEach(() => {
+    req = {
+      headers: {},
+      originalUrl: '/this/page',
+      query: {},
+      session: {},
+    }
+    next = jest.fn()
+
+    controller = referrerUrl()
+  })
+
+  describe('POST request', () => {
+    beforeEach(() => {
+      req.method = 'POST'
+    })
+
+    it('should not set a referrerUrl in session by default', async () => {
+      await controller(req, res, next)
+
+      expect(req.session.referrerUrl).toEqual(undefined)
+      expect(next).toHaveBeenCalled()
+    })
+  })
+
+  describe('GET request', () => {
+    beforeEach(() => {
+      req.method = 'GET'
+      req.headers = {
+        referer: 'https://localhost:3000/other/page',
+      }
+    })
+
+    it('should set referrerUrl in session when referer header is set', async () => {
+      await controller(req, res, next)
+
+      expect(req.session.referrerUrl).toEqual('https://localhost:3000/other/page')
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('should clear referrerUrl in session when referer header is undefined', async () => {
+      req.headers = {}
+
+      await controller(req, res, next)
+
+      expect(req.session.referrerUrl).toEqual(undefined)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('should clear referrerUrl in session when referer header points to the current page', async () => {
+      req.headers = {
+        referer: 'https://localhost:3000/this/page',
+      }
+
+      await controller(req, res, next)
+
+      expect(req.session.referrerUrl).toEqual(undefined)
+      expect(next).toHaveBeenCalled()
+    })
+  })
+})

--- a/server/middleware/referrerUrl.ts
+++ b/server/middleware/referrerUrl.ts
@@ -1,0 +1,14 @@
+import { NextFunction, Request, Response } from 'express'
+
+export default () => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    // Ignore form submissions, or redirects to the current page
+    if (req.method !== 'GET' || req.headers.referer?.endsWith(req.originalUrl)) {
+      return next()
+    }
+
+    req.session.referrerUrl = req.headers.referer
+
+    return next()
+  }
+}

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -25,7 +25,7 @@ export default function setUpWebSecurity(): Router {
   const fontSrc = ["'self'", 'data:']
   const imgSrc = ["'self'", 'data:']
   const connectSrc = ["'self'"]
-  const formAction = [`'self' ${config.apis.hmppsAuth.externalUrl}`]
+  const formAction = ["'self'", config.apis.hmppsAuth.externalUrl, config.prisonerProfileUrl]
 
   if (config.apis.frontendComponents.url) {
     scriptSrc.push(config.apis.frontendComponents.url)

--- a/server/views/receptionMove/considerRisksReception.njk
+++ b/server/views/receptionMove/considerRisksReception.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set title = "Consider risks of moving this person to reception" %}
 


### PR DESCRIPTION
- Added a middleware with some logic to keep track of the referring page even after form submissions.
- Fix some back links that still had the old relative path

[MAP-697]

[MAP-697]: https://dsdmoj.atlassian.net/browse/MAP-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ