### PR TITLE
MAP-794 changed tlsSecretName

### DIFF
--- a/helm_deploy/hmpps-change-someones-cell/values.yaml
+++ b/helm_deploy/hmpps-change-someones-cell/values.yaml
@@ -12,7 +12,7 @@ generic-service:
   ingress:
     enabled: true
     host: app-hostname.local # override per environment
-    tlsSecretName: hmpps-change-someones-cell-cert
+    tlsSecretName: hmpps-prisoner-cell-allocation-cert
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
Getting a Privacy error in UI. 
Need to ensure the tls cert name matches that in cloud platform namespace

![Screenshot 2024-03-19 at 15 35 59](https://github.com/ministryofjustice/hmpps-change-someones-cell/assets/50441412/02a5e027-da0c-45ec-a6d4-d4f39cb540a9)
