### PR TITLE
MAP-894 remove override of govuk-wrapper class 

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -1,3 +1,0 @@
-.govuk-main-wrapper {
-  min-height: 600px;
-}


### PR DESCRIPTION
as it was creating  a large space above footer