### PR TITLE
[MAP-960] Use express-async-errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "cookie-parser": "^1.4.6",
         "csurf": "^1.11.0",
         "express": "^4.18.2",
+        "express-async-errors": "^3.1.1",
         "express-prom-bundle": "^6.6.0",
         "express-session": "^1.17.3",
         "govuk_frontend_toolkit": "^9.0.1",
@@ -5252,6 +5253,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express-prom-bundle": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "cookie-parser": "^1.4.6",
     "csurf": "^1.11.0",
     "express": "^4.18.2",
+    "express-async-errors": "^3.1.1",
     "express-prom-bundle": "^6.6.0",
     "express-session": "^1.17.3",
     "govuk_frontend_toolkit": "^9.0.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import 'express-async-errors'
 
 import createError from 'http-errors'
 import cookieParser from 'cookie-parser'


### PR DESCRIPTION
This should stop it crashing pods when API calls fail. It should show the standard error page instead of an NginX 502 bad gateway error page.

[MAP-960]

[MAP-960]: https://dsdmoj.atlassian.net/browse/MAP-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ