### PR TITLE
MAP-1030 get internal location data from new locationsInsidePrisonApi

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,6 +6,7 @@ import components from './integration_tests/mockApis/components'
 import prisonApi from './integration_tests/mockApis/prisonApi'
 import users from './integration_tests/mockApis/users'
 import whereabouts from './integration_tests/mockApis/whereabouts'
+import locationsInsidePrisonApi from './integration_tests/mockApis/locationsInsidePrisonApi'
 import nonAssociationsApi from './integration_tests/mockApis/nonAssociationsApi'
 import prisonerSearchApi from './integration_tests/mockApis/prisonerSearchApi'
 
@@ -42,6 +43,7 @@ export default defineConfig({
             users.stubHealth(),
             prisonApi.stubHealth(),
             whereabouts.stubHealth(),
+            locationsInsidePrisonApi.stubHealth(),
             tokenVerification.stubHealth(),
           ]),
         stubLocationConfig: ({ agencyId, response }) => whereabouts.stubLocationConfig({ agencyId, response }),
@@ -50,7 +52,7 @@ export default defineConfig({
         stubInmates: prisonApi.stubInmates,
         stubOffenderFullDetails: fullDetails => Promise.all([prisonApi.stubOffenderFullDetails(fullDetails)]),
         stubOffenderNonAssociationsLegacy: response => nonAssociationsApi.stubOffenderNonAssociationsLegacy(response),
-        stubGroups: caseload => whereabouts.stubGroups(caseload),
+        stubGroups: caseload => locationsInsidePrisonApi.stubGroups(caseload),
         stubUserCaseLoads: caseloads => prisonApi.stubUserCaseloads(caseloads),
         stubMainOffence: offence => prisonApi.stubMainOffence(offence),
         stubOffenderBasicDetails: basicDetails => Promise.all([prisonApi.stubOffenderBasicDetails(basicDetails)]),

--- a/feature.env
+++ b/feature.env
@@ -15,4 +15,5 @@ DPS_URL=http://localhost:3100
 PRISONER_PROFILE_URL=http://localhost:3101
 NON_ASSOCIATIONS_API_URL=http://localhost:9091/non-associations
 WHEREABOUTS_API_URL=http://localhost:9091/whereabouts
+LOCATIONS_INSIDE_PRISON_API_URL=http://localhost:9091/locations-inside-prison-api
 PRISONER_SEARCH_API_URL=http://localhost:9091/prisoner-search

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,6 +19,7 @@ generic-service:
     PRISONER_PROFILE_URL: "http://prisoner-dev.digital.prison.service.justice.gov.uk"
     NON_ASSOCIATIONS_API_URL: "https://non-associations-api-dev.hmpps.service.justice.gov.uk"
     WHEREABOUTS_API_URL: "https://whereabouts-api-dev.service.justice.gov.uk"
+    LOCATIONS_INSIDE_PRISON_API_URL: "https://locations-inside-prison-api-dev.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -19,6 +19,7 @@ generic-service:
     PRISONER_PROFILE_URL: "https://prisoner-preprod.digital.prison.service.justice.gov.uk"
     NON_ASSOCIATIONS_API_URL: "https://non-associations-api-preprod.hmpps.service.justice.gov.uk"
     WHEREABOUTS_API_URL: "https://whereabouts-api-preprod.service.justice.gov.uk"
+    LOCATIONS_INSIDE_PRISON_API_URL: "https://locations-inside-prison-api-preprod.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-search-preprod.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -16,6 +16,7 @@ generic-service:
     PRISONER_PROFILE_URL: "https://prisoner.digital.prison.service.justice.gov.uk"
     NON_ASSOCIATIONS_API_URL: "https://non-associations-api.hmpps.service.justice.gov.uk"
     WHEREABOUTS_API_URL: "https://whereabouts-api.service.justice.gov.uk"
+    LOCATIONS_INSIDE_PRISON_API_URL: "https://locations-inside-prison-api.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-search.prison.service.justice.gov.uk"
 
   allowlist:

--- a/integration_tests/mockApis/locationsInsidePrisonApi.ts
+++ b/integration_tests/mockApis/locationsInsidePrisonApi.ts
@@ -1,0 +1,128 @@
+import { stubFor } from './wiremock'
+
+export const stubHealth = (status = 200) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPath: '/locations-inside-prison-api/health/ping',
+    },
+    response: {
+      status,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+    },
+  })
+
+export const stubGroups = (caseload, status = 200) => {
+  const json = [
+    {
+      name: '1',
+      key: '1',
+      children: [
+        {
+          name: 'A',
+          key: 'A',
+        },
+        {
+          name: 'B',
+          key: 'B',
+        },
+        {
+          name: 'C',
+          key: 'C',
+        },
+      ],
+    },
+    {
+      name: '2',
+      key: '2',
+      children: [
+        {
+          name: 'A',
+          key: 'A',
+        },
+        {
+          name: 'B',
+          key: 'B',
+        },
+        {
+          name: 'C',
+          key: 'C',
+        },
+      ],
+    },
+    {
+      name: '3',
+      key: '3',
+      children: [
+        {
+          name: 'A',
+          key: 'A',
+        },
+        {
+          name: 'B',
+          key: 'B',
+        },
+        {
+          name: 'C',
+          key: 'C',
+        },
+      ],
+    },
+  ]
+
+  const jsonSYI = [
+    {
+      name: 'block1',
+      key: 'block1',
+      children: [
+        {
+          name: 'A',
+          key: 'A',
+        },
+        {
+          name: 'B',
+          key: 'B',
+        },
+      ],
+    },
+    {
+      name: 'block2',
+      key: 'block2',
+      children: [
+        {
+          name: 'A',
+          key: 'A',
+        },
+        {
+          name: 'B',
+          key: 'B',
+        },
+        {
+          name: 'C',
+          key: 'C',
+        },
+      ],
+    },
+  ]
+
+  return stubFor({
+    request: {
+      method: 'GET',
+      url: `/locations-inside-prison-api/locations/prison/${caseload.id}/groups`,
+    },
+    response: {
+      status,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: caseload.id === 'SYI' ? jsonSYI : json,
+    },
+  })
+}
+
+export default {
+  stubHealth,
+  stubGroups,
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -122,6 +122,14 @@ export default {
       },
       agent: new AgentConfig(Number(get('WHEREABOUTS_API_TIMEOUT_RESPONSE', 10000))),
     },
+    locationsInsidePrisonApi: {
+      url: get('LOCATIONS_INSIDE_PRISON_API_URL', 'http://localhost:8083', requiredInProduction),
+      timeout: {
+        response: Number(get('LOCATIONS_INSIDE_PRISON_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('LOCATIONS_INSIDE_PRISON_API_TIMEOUT_DEADLINE', 10000)),
+      },
+      agent: new AgentConfig(Number(get('LOCATIONS_INSIDE_PRISON_API_TIMEOUT_RESPONSE', 10000))),
+    },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),

--- a/server/controllers/cellMove/cellMoveConfirmation.test.ts
+++ b/server/controllers/cellMove/cellMoveConfirmation.test.ts
@@ -7,7 +7,7 @@ jest.mock('../../services/locationService')
 jest.mock('../../services/prisonerDetailsService')
 
 describe('Cell move confirmation', () => {
-  const locationService = jest.mocked(new LocationService(undefined, undefined))
+  const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 
   let controller

--- a/server/controllers/cellMove/cellMoveHistory.test.ts
+++ b/server/controllers/cellMove/cellMoveHistory.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../services/prisonerCellAllocationService')
 jest.mock('../../services/prisonerDetailsService')
 
 describe('Cell move history', () => {
-  const locationService = jest.mocked(new LocationService(undefined, undefined))
+  const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
   const userService = jest.mocked(new UserService(undefined, undefined))

--- a/server/controllers/cellMove/cellMoveViewResidentialLocation.test.ts
+++ b/server/controllers/cellMove/cellMoveViewResidentialLocation.test.ts
@@ -6,7 +6,7 @@ jest.mock('../../services/locationService')
 jest.mock('../../services/prisonerCellAllocationService')
 
 describe('View Residential Location', () => {
-  const locationService = jest.mocked(new LocationService(undefined, undefined))
+  const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
 
   let req

--- a/server/controllers/cellMove/confirmCellMove.test.ts
+++ b/server/controllers/cellMove/confirmCellMove.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../services/prisonerDetailsService')
 
 describe('Change cell play back details', () => {
   const analyticsService = jest.mocked(new AnalyticsService(undefined))
-  const locationService = jest.mocked(new LocationService(undefined, undefined))
+  const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 

--- a/server/controllers/cellMove/considerRisks.test.ts
+++ b/server/controllers/cellMove/considerRisks.test.ts
@@ -18,7 +18,7 @@ jest.mock('../../services/prisonerDetailsService')
 
 describe('move validation', () => {
   const analyticsService = jest.mocked(new AnalyticsService(undefined))
-  const locationService = jest.mocked(new LocationService(undefined, undefined))
+  const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const nonAssociationsService = jest.mocked(new NonAssociationsService(undefined))
   const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))

--- a/server/controllers/cellMove/searchForCell.test.ts
+++ b/server/controllers/cellMove/searchForCell.test.ts
@@ -7,7 +7,7 @@ import NonAssociationsService from '../../services/nonAssociationsService'
 Reflect.deleteProperty(process.env, 'APPINSIGHTS_INSTRUMENTATIONKEY')
 
 describe('select location', () => {
-  const locationService = jest.mocked(new LocationService(undefined, undefined))
+  const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const nonAssociationsService = jest.mocked(new NonAssociationsService(undefined))
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 

--- a/server/controllers/cellMove/selectCell.test.ts
+++ b/server/controllers/cellMove/selectCell.test.ts
@@ -136,7 +136,7 @@ describe('Select a cell', () => {
       {
         name: 'Houseblock 1',
         key: 'hb1',
-        children: [{ name: 'Sub value', key: 'sl' }],
+        children: [{ name: 'Sub value', key: 'sl', children: [] }],
       },
     ]
 

--- a/server/controllers/cellMove/selectCell.test.ts
+++ b/server/controllers/cellMove/selectCell.test.ts
@@ -16,7 +16,7 @@ const someBookingId = -10
 const someAgency = 'LEI'
 
 describe('Select a cell', () => {
-  const locationService = jest.mocked(new LocationService(undefined, undefined))
+  const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const nonAssociationsService = jest.mocked(new NonAssociationsService(undefined))
   const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))

--- a/server/controllers/cellMove/viewCellSharingRiskAssessment.test.ts
+++ b/server/controllers/cellMove/viewCellSharingRiskAssessment.test.ts
@@ -9,7 +9,7 @@ jest.mock('../../services/locationService')
 jest.mock('../../services/prisonerDetailsService')
 
 describe('view CSRA details', () => {
-  const locationService = jest.mocked(new LocationService(undefined, undefined))
+  const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 
   let req

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -17,6 +17,7 @@ import TokenStore from './tokenStore'
 import FeComponentsClient from './feComponentsClient'
 import PrisonApiClient from './prisonApiClient'
 import WhereaboutsApiClient from './whereaboutsApiClient'
+import LocationsInsidePrisonApiClient from './locationsInsidePrisonApiClient'
 import NonAssociationsApiClient from './nonAssociationsApiClient'
 import GoogleAnalyticsClient from './googleAnalyticsClient'
 import PrisonerSearchApiClient from './prisonerSearchApiClient'
@@ -30,6 +31,7 @@ export const dataAccess = () => ({
   feComponentsClient: new FeComponentsClient(),
   prisonApiClient: new PrisonApiClient(),
   whereaboutsApiClient: new WhereaboutsApiClient(),
+  locationsInsidePrisonApiClient: new LocationsInsidePrisonApiClient(),
   nonAssociationsApiClient: new NonAssociationsApiClient(),
   googleAnalyticsClient: new GoogleAnalyticsClient(),
   prisonerSearchApiClient: new PrisonerSearchApiClient(),
@@ -43,6 +45,7 @@ export {
   ManageUsersApiClient,
   PrisonApiClient,
   WhereaboutsApiClient,
+  LocationsInsidePrisonApiClient,
   NonAssociationsApiClient,
   GoogleAnalyticsClient,
   PrisonerSearchApiClient,

--- a/server/data/locationsInsidePrisonApiClient.test.ts
+++ b/server/data/locationsInsidePrisonApiClient.test.ts
@@ -1,0 +1,37 @@
+import nock from 'nock'
+
+import config from '../config'
+import LocationsInsidePrisonApiClient from './locationsInsidePrisonApiClient'
+
+jest.mock('./tokenStore')
+
+const accessToken = 'token-1'
+
+describe('LocationsInsidePrisonApiClient', () => {
+  let fakeLocationsInsidePrisonApiClient: nock.Scope
+  let locationsInsidePrisonApiClient: LocationsInsidePrisonApiClient
+
+  beforeEach(() => {
+    fakeLocationsInsidePrisonApiClient = nock(config.apis.locationsInsidePrisonApi.url)
+    locationsInsidePrisonApiClient = new LocationsInsidePrisonApiClient()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+
+  describe('searchGroups', () => {
+    it('should return data from api', async () => {
+      const response = { data: 'data' }
+
+      fakeLocationsInsidePrisonApiClient
+        .get('/locations/prison/BXI/groups')
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .reply(200, response)
+
+      const output = await locationsInsidePrisonApiClient.searchGroups(accessToken, 'BXI')
+      expect(output).toEqual(response)
+    })
+  })
+})

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -10,17 +10,6 @@ export interface LocationGroup {
   }[]
 }
 
-export interface CellMoveResponse {
-  cellMoveResult: {
-    bookingId: number
-    agencyId: string
-    assignedLivingUnitId: number
-    assignedLivingUnitDesc: string
-    bedAssignmentHistorySequence: number
-    caseNoteId: number
-  }
-}
-
 export interface LocationPrefix {
   locationPrefix: string
 }

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -1,0 +1,40 @@
+import config from '../config'
+import RestClient from './restClient'
+
+export interface LocationGroup {
+  name: string
+  key: string
+  children: {
+    key: string
+    name: string
+  }[]
+}
+
+export interface CellMoveResponse {
+  cellMoveResult: {
+    bookingId: number
+    agencyId: string
+    assignedLivingUnitId: number
+    assignedLivingUnitDesc: string
+    bedAssignmentHistorySequence: number
+    caseNoteId: number
+  }
+}
+
+export interface LocationPrefix {
+  locationPrefix: string
+}
+
+export default class LocationsInsidePrisonApiClient {
+  constructor() {}
+
+  private restClient(token: string): RestClient {
+    return new RestClient('Locations inside prison Api Client', config.apis.locationsInsidePrisonApi, token)
+  }
+
+  searchGroups(token: string, prisonId: string): Promise<LocationGroup[]> {
+    return this.restClient(token).get<LocationGroup[]>({
+      path: `/locations/prison/${prisonId}/groups`,
+    })
+  }
+}

--- a/server/data/whereaboutsApiClient.test.ts
+++ b/server/data/whereaboutsApiClient.test.ts
@@ -21,20 +21,6 @@ describe('whereaboutsApiClient', () => {
     nock.cleanAll()
   })
 
-  describe('searchGroups', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakeWhereaboutsApiClient
-        .get('/agencies/BXI/locations/groups')
-        .matchHeader('authorization', `Bearer ${accessToken}`)
-        .reply(200, response)
-
-      const output = await whereaboutsApiClient.searchGroups(accessToken, 'BXI')
-      expect(output).toEqual(response)
-    })
-  })
-
   describe('getCellsWithCapacity', () => {
     it('should return data from api', async () => {
       const response = { data: 'data' }

--- a/server/data/whereaboutsApiClient.ts
+++ b/server/data/whereaboutsApiClient.ts
@@ -5,10 +5,7 @@ import RestClient from './restClient'
 export interface LocationGroup {
   name: string
   key: string
-  children: {
-    key: string
-    name: string
-  }[]
+  children: LocationGroup[]
 }
 
 export interface CellMoveResponse {

--- a/server/data/whereaboutsApiClient.ts
+++ b/server/data/whereaboutsApiClient.ts
@@ -33,12 +33,6 @@ export default class WhereaboutsApiClient {
     return new RestClient('Whereabouts Api Client', config.apis.whereaboutsApi, token)
   }
 
-  searchGroups(token: string, agencyId: string): Promise<LocationGroup[]> {
-    return WhereaboutsApiClient.restClient(token).get<LocationGroup[]>({
-      path: `/agencies/${agencyId}/locations/groups`,
-    })
-  }
-
   getCellsWithCapacity(token: string, agencyId: string, groupName: string) {
     return WhereaboutsApiClient.restClient(token).get<OffenderCell[]>({
       path: `/locations/cellsWithCapacity/${agencyId}/${groupName}`,

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -14,6 +14,7 @@ export const services = () => {
     feComponentsClient,
     prisonApiClient,
     whereaboutsApiClient,
+    locationsInsidePrisonApiClient,
     nonAssociationsApiClient,
     googleAnalyticsClient,
     prisonerSearchApiClient,
@@ -27,7 +28,7 @@ export const services = () => {
     prisonerSearchApiClient,
   )
   const prisonerDetailsService = new PrisonerDetailsService(prisonApiClient)
-  const locationService = new LocationService(prisonApiClient, whereaboutsApiClient)
+  const locationService = new LocationService(prisonApiClient, whereaboutsApiClient, locationsInsidePrisonApiClient)
   const nonAssociationsService = new NonAssociationsService(nonAssociationsApiClient)
   const analyticsService = new AnalyticsService(googleAnalyticsClient)
 

--- a/server/services/locationService.test.ts
+++ b/server/services/locationService.test.ts
@@ -27,21 +27,38 @@ describe('Location service', () => {
   describe('searchGroups', () => {
     const locationGroups: LocationGroup[] = [
       { name: 'A Wing', key: 'A', children: [] },
-      { name: 'B Wing', key: 'B', children: [] },
+      { name: 'B Wing', key: 'B', children: [{ name: 'child-B', key: 'child-B', children: [] }] },
+      {
+        name: 'C Wing',
+        key: 'C',
+        children: [
+          { name: 'child-C1', key: 'child-C1', children: [] },
+          { name: 'child-C2', key: 'child-C2', children: [] },
+        ],
+      },
     ]
 
-    it('retrieves location groups', async () => {
+    const locationGroupsWithSingleChildrenReduced: LocationGroup[] = [
+      { name: 'A Wing', key: 'A', children: [] },
+      { name: 'B Wing', key: 'B', children: [] },
+      {
+        name: 'C Wing',
+        key: 'C',
+        children: [
+          { name: 'child-C1', key: 'child-C1', children: [] },
+          { name: 'child-C2', key: 'child-C2', children: [] },
+        ],
+      },
+    ]
+
+    it('retrieves location groups and reduces single children to empty array', async () => {
       locationsInsidePrisonApiClient.searchGroups.mockResolvedValue(locationGroups)
-
       const results = await locationService.searchGroups(token, 'BXI')
-
       expect(locationsInsidePrisonApiClient.searchGroups).toHaveBeenCalledTimes(1)
-      expect(results).toEqual(locationGroups)
+      expect(results).toEqual(locationGroupsWithSingleChildrenReduced)
     })
-
     it('Propagates error', async () => {
       locationsInsidePrisonApiClient.searchGroups.mockRejectedValue(new Error('some error'))
-
       await expect(locationService.searchGroups(token, 'BXI')).rejects.toEqual(new Error('some error'))
     })
   })

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -1,15 +1,16 @@
-import { PrisonApiClient, WhereaboutsApiClient } from '../data'
+import { PrisonApiClient, WhereaboutsApiClient, LocationsInsidePrisonApiClient } from '../data'
 import { Agency, Location, OffenderCell } from '../data/prisonApiClient'
-import { LocationGroup, LocationPrefix } from '../data/whereaboutsApiClient'
+import { LocationGroup, LocationPrefix } from '../data/locationsInsidePrisonApiClient'
 
 export default class LocationService {
   constructor(
     private readonly prisonApiClient: PrisonApiClient,
     private readonly whereaboutsApiClient: WhereaboutsApiClient,
+    private readonly locationsInsidePrisonApiClient: LocationsInsidePrisonApiClient,
   ) {}
 
   async searchGroups(token: string, agencyId: string): Promise<LocationGroup[]> {
-    return await this.whereaboutsApiClient.searchGroups(token, agencyId)
+    return await this.locationsInsidePrisonApiClient.searchGroups(token, agencyId)
   }
 
   async getLocation(token: string, livingUnitId: number): Promise<Location> {

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -10,7 +10,10 @@ export default class LocationService {
   ) {}
 
   async searchGroups(token: string, agencyId: string): Promise<LocationGroup[]> {
-    return await this.locationsInsidePrisonApiClient.searchGroups(token, agencyId)
+    const groups = await this.locationsInsidePrisonApiClient.searchGroups(token, agencyId)
+    return groups.map(group =>
+      group.children.length === 1 ? { name: group.name, key: group.key, children: [] } : group,
+    )
   }
 
   async getLocation(token: string, livingUnitId: number): Promise<Location> {


### PR DESCRIPTION
swap to get internal location **Group** data from new locationsInsidePrisonApi instead of whereaboutsApi
endpoint called in whereabouts was /agencies/${agencyId}/locations/groups
endpoint in new locationsInsidePrisonApi is /locations/prison/${prisonId}/groups


MAP-1267 investigation has identified that locations that had  a single child location had their 'children' reduced to an empty array in prison-api. As we want to replicate this in our service but without it being dictated by the new locationsInsidePrisonApi, the reduction has been done in the CSC UI app. 