### PR TITLE
[MAP-1257] Normalise prison numbers in metrics

### DIFF
--- a/server/monitoring/metricsApp.ts
+++ b/server/monitoring/metricsApp.ts
@@ -8,6 +8,10 @@ const metricsMiddleware = promBundle({
   includeMethod: true,
   includePath: true,
   normalizePath: [['^/assets/.+$', '/assets/#assetPath']],
+  urlValueParser: {
+    minHexLength: 7,
+    extraMasks: ['[A-Z][0-9]{4}[A-Z]{2}'],
+  },
 })
 
 function metricsPort(): number {


### PR DESCRIPTION
We are getting out of memory errors and it may be because Prometheus has a bucket in memory for every possible path for every prison number. This config change should replace all prisoner numbers in paths with '#val'.

[MAP-1257]

[MAP-1257]: https://dsdmoj.atlassian.net/browse/MAP-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ