### PR TITLE
[MAP-1257] Install procps in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV GIT_BRANCH=${GIT_BRANCH}
 
 RUN apt-get update && \
         apt-get upgrade -y && \
+        apt-get install -y procps && \
         apt-get autoremove -y && \
         rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
For some reason this isn't installed by default. We need to be able to use `ps` on the command line in order to diagnose a memory leak.

[MAP-1257]

[MAP-1257]: https://dsdmoj.atlassian.net/browse/MAP-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ