### PR TITLE
MAP-1283 prevent call to get the prisoners at a location..

### DIFF
--- a/server/controllers/cellMove/selectCell.test.ts
+++ b/server/controllers/cellMove/selectCell.test.ts
@@ -379,6 +379,66 @@ describe('Select a cell', () => {
         'sub1',
       )
     })
+
+    it('should not make a call to retrieve prisoners to get single capacity cells if there are only multi capacity cells at that location', async () => {
+      req.query = {
+        location: 'hb1',
+        subLocation: 'sub1',
+        cellType: 'SO',
+      }
+      prisonerCellAllocationService.getCellsWithCapacity.mockResolvedValue([
+        {
+          id: 1,
+          description: 'MDI-1',
+          noOfOccupants: 0,
+          capacity: 2,
+          attributes: [],
+        },
+      ])
+      await controller(req, res)
+
+      expect(prisonerCellAllocationService.getPrisonersAtLocations).not.toHaveBeenCalled()
+    })
+
+    it('should not make a call to retrieve prisoners to get multi capacity cells if there are only single capacity cells at that location', async () => {
+      req.query = {
+        location: 'hb1',
+        subLocation: 'sub1',
+        cellType: 'MO',
+      }
+      prisonerCellAllocationService.getCellsWithCapacity.mockResolvedValue([
+        {
+          id: 1,
+          description: 'MDI-1',
+          noOfOccupants: 0,
+          capacity: 1,
+          attributes: [],
+        },
+      ])
+      await controller(req, res)
+
+      expect(prisonerCellAllocationService.getPrisonersAtLocations).not.toHaveBeenCalled()
+    })
+
+    it('should make a call to retrieve prisoners at location', async () => {
+      req.query = {
+        location: 'hb1',
+        subLocation: 'sub1',
+        cellType: 'MO',
+      }
+      prisonerCellAllocationService.getCellsWithCapacity.mockResolvedValue([
+        {
+          id: 1,
+          description: 'MDI-1',
+          noOfOccupants: 0,
+          capacity: 2,
+          attributes: [],
+        },
+      ])
+      await controller(req, res)
+
+      expect(prisonerCellAllocationService.getPrisonersAtLocations).toHaveBeenCalled()
+    })
   })
 
   describe('Cell types', () => {

--- a/server/controllers/cellMove/selectCell.ts
+++ b/server/controllers/cellMove/selectCell.ts
@@ -39,11 +39,15 @@ const getCellOccupants = async (
   },
 ) => {
   const cellDescriptions = cells.map(cell => stripAgencyPrefix(cell.description, activeCaseLoadId))
-  const currentCellOccupants = await prisonerCellAllocationService.getPrisonersAtLocations(
-    res.locals.systemClientToken,
-    activeCaseLoadId,
-    cellDescriptions,
-  )
+
+  let currentCellOccupants = []
+
+  if (cellDescriptions.length)
+    currentCellOccupants = await prisonerCellAllocationService.getPrisonersAtLocations(
+      res.locals.systemClientToken,
+      activeCaseLoadId,
+      cellDescriptions,
+    )
 
   if (!hasLength(currentCellOccupants)) return []
 


### PR DESCRIPTION
.. when there are zero locations

This is fix for a 400 error that arises when we attempt to get prisoners at a location without providing a list of locations. 


