### PR TITLE
[MAP-1257] Avoid instantiating a new Redis client every time the populateClientToken middleware runs

### DIFF
--- a/server/middleware/populateClientToken.ts
+++ b/server/middleware/populateClientToken.ts
@@ -3,9 +3,10 @@ import logger from '../../logger'
 import { dataAccess } from '../data'
 
 export default function populateClientToken(): RequestHandler {
+  const { hmppsAuthClient } = dataAccess()
+
   return async (_req, res, next) => {
     try {
-      const { hmppsAuthClient } = dataAccess()
       if (res.locals.user) {
         const clientToken = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
         if (clientToken) {


### PR DESCRIPTION
Avoid instantiating a new Redis client every time the populateClientToken middleware runs to try and fix the memory leak and 500 response code issues