### PR TITLE
Map 1350 csc replacing prison api calls with locations api 1

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -57,12 +57,12 @@ export default defineConfig({
         stubMainOffence: offence => prisonApi.stubMainOffence(offence),
         stubOffenderBasicDetails: basicDetails => Promise.all([prisonApi.stubOffenderBasicDetails(basicDetails)]),
         stubCellAttributes: prisonApi.stubCellAttributes,
-        stubInmatesAtLocation: ({ inmates }) => prisonApi.stubInmatesAtLocation(inmates),
+        stubInmatesAtLocation: inmates => locationsInsidePrisonApi.stubInmatesAtLocation(inmates),
         stubOffenderCellHistory: ({ history }) => prisonApi.stubOffenderCellHistory(history),
         stubGetAlerts: ({ agencyId, alerts }) => prisonApi.stubGetAlerts({ agencyId, alerts }),
         stubCsraAssessments: ({ offenderNumbers, assessments }) =>
           prisonApi.stubCsraAssessments(offenderNumbers, assessments),
-        stubLocation: ({ locationId, locationData }) => Promise.all([prisonApi.stubLocation(locationId, locationData)]),
+        stubLocation: location => locationsInsidePrisonApi.stubLocation(location),
         stubCellsWithCapacity: ({ cells }) => prisonApi.stubCellsWithCapacity(cells),
         stubCellsWithCapacityByGroupName: ({ agencyId, groupName, response }) =>
           whereabouts.stubCellsWithCapacityByGroupName({ agencyId, groupName, response }),

--- a/integration_tests/e2e/cellMoveConfirmation.cy.ts
+++ b/integration_tests/e2e/cellMoveConfirmation.cy.ts
@@ -2,7 +2,7 @@ import cellConfirmationPage from '../pages/cellMoveConfirmationPage'
 import homePage from '../pages/homePage'
 
 const offenderNo = 'A1234A'
-const cellId = 1
+const cellId = 'MDI-1-1-1'
 
 context('A user get confirmation of a cell move', () => {
   before(() => {
@@ -20,14 +20,20 @@ context('A user get confirmation of a cell move', () => {
       bookingId: 1234,
     })
     cy.task('stubLocation', {
-      locationId: 1,
-      locationData: { parentLocationId: 2, description: 'MDI-1-1', locationPrefix: 'MDI-1' },
+      prisonId: 'MDI',
+      parentId: 'uuid',
+      key: 'MDI-1-1-1',
+      pathHierarchy: '1-1-1',
+      capacity: {
+        maxCapacity: 2,
+        workingCapacity: 2,
+      },
     })
     cy.task('stubMoveToCell')
   })
 
   it('should page with the correct offender name and cell description', () => {
-    const page = cellConfirmationPage.goTo({ offenderNo, cellId, cellDescription: 'MDI-1-1', name: 'Bob Doe' })
+    const page = cellConfirmationPage.goTo({ offenderNo, cellId, cellDescription: '1-1-1', name: 'Bob Doe' })
 
     cy.title().should('eq', `Change Someone's Cell - The prisoner’s cell has been changed`)
 

--- a/integration_tests/e2e/confirmCellMove.cy.ts
+++ b/integration_tests/e2e/confirmCellMove.cy.ts
@@ -21,8 +21,14 @@ context('A user can confirm the cell move', () => {
       bookingId,
     })
     cy.task('stubLocation', {
-      locationId: 1,
-      locationData: { parentLocationId: 2, description: 'MDI-1-1', locationPrefix: 'MDI-1' },
+      prisonId: 'MDI',
+      parentId: 'uuid',
+      key: 'MDI-1-1-1',
+      pathHierarchy: '1-1-1',
+      capacity: {
+        maxCapacity: 2,
+        workingCapacity: 2,
+      },
     })
     cy.task('stubMoveToCell')
     cy.task('stubMoveToCellSwap')
@@ -44,13 +50,13 @@ context('A user can confirm the cell move', () => {
   })
 
   it('should display correct location and warning text', () => {
-    const page = ConfirmCellMovePage.goTo('A12345', 1, 'Bob Doe', 'MDI-1-1')
+    const page = ConfirmCellMovePage.goTo('A12345', 'MDI-1-1-1', 'Bob Doe', '1-1-1')
 
     page.warning().contains('You must have checked any local processes for non-associations.')
   })
 
   it('should make a call to update an offenders cell', () => {
-    const page = ConfirmCellMovePage.goTo(offenderNo, 1, 'Bob Doe', 'MDI-1-1')
+    const page = ConfirmCellMovePage.goTo(offenderNo, 'MDI-1-1-1', 'Bob Doe', '1-1-1')
     const comment = 'Hello world'
     page.form().reason().click()
     page.form().comment().type(comment)
@@ -60,7 +66,7 @@ context('A user can confirm the cell move', () => {
       bookingId,
       offenderNo,
       cellMoveReasonCode: 'ADM',
-      internalLocationDescriptionDestination: 'MDI-1',
+      internalLocationDescriptionDestination: 'MDI-1-1-1',
       commentText: comment,
     }).then(assertHasRequestCount(1))
 
@@ -68,7 +74,7 @@ context('A user can confirm the cell move', () => {
   })
 
   it('should navigate back to search for cell', () => {
-    const page = ConfirmCellMovePage.goTo('A12345', 1, 'Bob Doe', 'MDI-1-1')
+    const page = ConfirmCellMovePage.goTo('A12345', 'MDI-1-1-1', 'Bob Doe', '1-1-1')
 
     page.backLink().contains('Cancel')
     page.backLink().click()
@@ -77,7 +83,7 @@ context('A user can confirm the cell move', () => {
   })
 
   it('should have a back button leading to search for cell', () => {
-    ConfirmCellMovePage.goTo('A12345', 1, 'Bob Doe', 'MDI-1-1')
+    ConfirmCellMovePage.goTo('A12345', 'MDI-1-1-1', 'Bob Doe', '1-1-1')
 
     cy.contains('Back').click()
 

--- a/integration_tests/e2e/considerRisks.cy.ts
+++ b/integration_tests/e2e/considerRisks.cy.ts
@@ -419,6 +419,7 @@ context('A user can see conflicts in cell', () => {
   it('should redirect to confirm cell when there are no warnings', () => {
     cy.task('stubOffenderNonAssociationsLegacy', {})
 
+    cy.task('stubInmatesAtLocation', [])
     cy.task('stubBookingDetails', {
       firstName: 'Bob',
       lastName: 'Doe',
@@ -445,7 +446,9 @@ context('A user can see conflicts in cell', () => {
     ConfirmCellMovePage.verifyOnPage('Bob Doe', '1-1-1')
   })
 
-  xit('should not show CSRA messages and have the correct confirmation label', () => {
+  it('should not show CSRA messages and have the correct confirmation label', () => {
+    cy.task('stubInmatesAtLocation', [])
+
     cy.task('stubOffenderFullDetails', offenderFullDetails)
 
     const page = ConsiderRisksPage.goTo(offenderNo, 'MDI-1-1-1')

--- a/integration_tests/e2e/selectCell.cy.ts
+++ b/integration_tests/e2e/selectCell.cy.ts
@@ -40,9 +40,6 @@ context('A user can select a cell', () => {
     })
     cy.task('stubGroups', { id: 'MDI' })
     cy.task('stubCellAttributes')
-    cy.task('stubInmatesAtLocation', {
-      inmates: [{ offenderNo: 'A12345', firstName: 'Bob', lastName: 'Doe', assignedLivingUnitId: 1 }],
-    })
     cy.task('stubPrisonersAtLocations', {
       prisoners: [
         {
@@ -89,9 +86,6 @@ context('A user can select a cell', () => {
       ],
     })
 
-    cy.task('stubLocation', { locationId: 1, locationData: { parentLocationId: 2, description: 'MDI-1-1' } })
-    cy.task('stubLocation', { locationId: 2, locationData: { parentLocationId: 3 } })
-    cy.task('stubLocation', { locationId: 3, locationData: { locationPrefix: 'MDI-1' } })
     cy.task('stubUserCaseLoads')
   })
 
@@ -260,12 +254,23 @@ context('A user can select a cell', () => {
           cy.task('stubOffenderNonAssociationsLegacy', {})
           cy.task('stubGroups', { id: 'MDI' })
           cy.task('stubUserCaseLoads')
-          cy.task('stubLocation', { locationId: 1, locationData: { parentLocationId: 2, description: 'MDI-1-1' } })
-          cy.task('stubLocation', { locationId: 2, locationData: { parentLocationId: 3 } })
-          cy.task('stubLocation', { locationId: 3, locationData: { locationPrefix: 'MDI-1' } })
-          cy.task('stubInmatesAtLocation', {
-            inmates: [{ offenderNo: 'A12345', firstName: 'Bob', lastName: 'Doe', assignedLivingUnitId: 1 }],
-          })
+          cy.task('stubLocation', {})
+          cy.task('stubInmatesAtLocation', [
+            {
+              cellLocation: 'MDI-1-1-1',
+              prisoners: [
+                {
+                  prisonerNumber: 'A12345',
+                  firstName: 'BOB',
+                  lastName: 'DOE',
+                  prisonId: 'MDI',
+                  prisonName: 'Moorland (HMP)',
+                  cellLocation: '1-1-1',
+                },
+              ],
+            },
+          ])
+
           cy.task('stubPrisonersAtLocations', {
             prisoners: [
               {
@@ -286,7 +291,7 @@ context('A user can select a cell', () => {
             nonAssociations: [],
           })
 
-          ConsiderRisksPage.goTo(offenderNo, 1)
+          ConsiderRisksPage.goTo(offenderNo, 'MDI-1-1-1')
           cy.contains('Back').click()
           cy.contains('Select an available cell')
         })

--- a/integration_tests/mockApis/locationsInsidePrisonApi.ts
+++ b/integration_tests/mockApis/locationsInsidePrisonApi.ts
@@ -122,7 +122,41 @@ export const stubGroups = (caseload, status = 200) => {
   })
 }
 
+export const stubLocation = location => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: '/locations-inside-prison-api/locations/key/.+',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: location || {},
+    },
+  })
+}
+
+export const stubInmatesAtLocation = inmates => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: '/locations-inside-prison-api/prisoner-locations/key/.+',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: inmates || [],
+    },
+  })
+}
+
 export default {
   stubHealth,
   stubGroups,
+  stubLocation,
+  stubInmatesAtLocation,
 }

--- a/integration_tests/mockApis/prisonApi.ts
+++ b/integration_tests/mockApis/prisonApi.ts
@@ -243,29 +243,6 @@ export const stubCsraAssessments = (offenderNumbers, assessments = []) =>
     },
   })
 
-export const stubLocation = (locationId, locationData, status = 200) =>
-  stubFor({
-    request: {
-      method: 'GET',
-      url: `/api/locations/${locationId}`,
-    },
-    response: {
-      status,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: locationData || {
-        locationId,
-        locationType: 'WING',
-        description: 'HB1',
-        agencyId: 'RNI',
-        currentOccupancy: 243,
-        locationPrefix: 'RNI-HB1',
-        internalLocationCode: 'HB1',
-      },
-    },
-  })
-
 export const stubCellsWithCapacity = cells =>
   stubFor({
     request: {
@@ -497,7 +474,6 @@ export default {
   stubOffenderCellHistory,
   stubGetAlerts,
   stubCsraAssessments,
-  stubLocation,
   stubCellsWithCapacity,
   stubSpecificOffenderFullDetails,
   stubPrisonerFullDetail,

--- a/integration_tests/mockApis/prisonApi.ts
+++ b/integration_tests/mockApis/prisonApi.ts
@@ -183,21 +183,6 @@ export const stubCellAttributes = cellAttributes =>
     },
   })
 
-export const stubInmatesAtLocation = inmates =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPathPattern: '/api/locations/.+?/inmates',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: inmates || [],
-    },
-  })
-
 export const stubOffenderCellHistory = history =>
   stubFor({
     request: {
@@ -470,7 +455,6 @@ export default {
   stubMainOffence,
   stubOffenderBasicDetails,
   stubCellAttributes,
-  stubInmatesAtLocation,
   stubOffenderCellHistory,
   stubGetAlerts,
   stubCsraAssessments,

--- a/server/controllers/cellMove/cellMoveConfirmation.test.ts
+++ b/server/controllers/cellMove/cellMoveConfirmation.test.ts
@@ -11,23 +11,31 @@ describe('Cell move confirmation', () => {
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 
   let controller
-  const req = { params: { offenderNo: 'A12345' }, query: { cellId: 1 }, originalUrl: 'http://localhost' }
+  const req = { params: { offenderNo: 'A12345' }, query: { cellId: 'MDI-A-1-1' }, originalUrl: 'http://localhost' }
   let res
 
   const systemClientToken = 'system_token'
+
+  const location = {
+    prisonId: 'MDI',
+    parentId: 'some-uuid',
+    key: 'MDI-A-1-1',
+    pathHierarchy: 'A-1-1',
+    capacity: { maxCapacity: 2, workingCapacity: 2 },
+  }
 
   beforeEach(() => {
     prisonerDetailsService.getDetails = jest
       .fn()
       .mockResolvedValue({ firstName: 'Bob', lastName: 'Doe', agencyId: 'MDI' })
-    locationService.getLocation = jest.fn().mockResolvedValue({ description: 'A-1-012' })
+    locationService.getLocation = jest.fn().mockResolvedValue(location)
     controller = cellMoveConfirmation({ locationService, prisonerDetailsService })
 
     res = {
       locals: {
         user: {
-          activeCaseLoad: { caseLoadId: 'LEI' },
-          allCaseloads: [{ caseLoadId: 'LEI' }],
+          activeCaseLoad: { caseLoadId: 'MDI' },
+          allCaseloads: [{ caseLoadId: 'MDI' }],
           userRoles: ['ROLE_CELL_MOVE'],
         },
         systemClientToken,
@@ -46,7 +54,7 @@ describe('Cell move confirmation', () => {
   it('should make call to retrieve location details', async () => {
     await controller(req, res)
 
-    expect(locationService.getLocation).toHaveBeenCalledWith(systemClientToken, 1)
+    expect(locationService.getLocation).toHaveBeenCalledWith(systemClientToken, 'MDI-A-1-1')
   })
 
   it('should render the confirmation page', async () => {
@@ -56,7 +64,7 @@ describe('Cell move confirmation', () => {
       'cellMove/confirmation.njk',
       expect.objectContaining({
         backToStartUrl: '/back-to-start?serviceUrlParams[offenderNo]=A12345',
-        confirmationMessage: 'Bob Doe has been moved to cell A-1-012',
+        confirmationMessage: 'Bob Doe has been moved to cell A-1-1',
       }),
     )
   })

--- a/server/controllers/cellMove/cellMoveConfirmation.ts
+++ b/server/controllers/cellMove/cellMoveConfirmation.ts
@@ -16,11 +16,11 @@ export default ({ locationService, prisonerDetailsService }: Params) =>
     try {
       const { cellId } = req.query
       const { firstName, lastName } = await prisonerDetailsService.getDetails(systemClientToken, offenderNo)
-      const { description } = await locationService.getLocation(systemClientToken, cellId)
+      const { pathHierarchy } = await locationService.getLocation(systemClientToken, cellId)
 
       return res.render('cellMove/confirmation.njk', {
         backToStartUrl: `/back-to-start?serviceUrlParams[offenderNo]=${offenderNo}`,
-        confirmationMessage: `${formatName(firstName, lastName)} has been moved to cell ${description}`,
+        confirmationMessage: `${formatName(firstName, lastName)} has been moved to cell ${pathHierarchy}`,
       })
     } catch (error) {
       res.locals.redirectUrl = `/prisoner/${offenderNo}/cell-move/search-for-cell`

--- a/server/controllers/cellMove/selectCell.test.ts
+++ b/server/controllers/cellMove/selectCell.test.ts
@@ -3,7 +3,7 @@ import LocationService from '../../services/locationService'
 import NonAssociationsService from '../../services/nonAssociationsService'
 import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
 import PrisonerDetailsService from '../../services/prisonerDetailsService'
-import { Alert, Location, Offender } from '../../data/prisonApiClient'
+import { Alert, Offender } from '../../data/prisonApiClient'
 import { LocationGroup } from '../../data/whereaboutsApiClient'
 
 jest.mock('../../services/locationService')
@@ -24,36 +24,6 @@ describe('Select a cell', () => {
   let controller
   let req
   let res
-
-  const location: Location = {
-    locationId: 0,
-    locationType: 'string',
-    description: 'string',
-    locationUsage: 'string',
-    agencyId: 'string',
-    parentLocationId: 0,
-    currentOccupancy: 0,
-    locationPrefix: 'string',
-    operationalCapacity: 0,
-    userDescription: 'string',
-    internalLocationCode: 'string',
-    subLocations: true,
-  }
-
-  const cellLocationData = {
-    ...location,
-    parentLocationId: 2,
-  }
-
-  const parentLocationData = {
-    ...location,
-    parentLocationId: 3,
-  }
-
-  const superParentLocationData = {
-    ...location,
-    locationPrefix: 'MDI-1',
-  }
 
   const offender: Offender = {
     bookingId: 1,
@@ -140,7 +110,6 @@ describe('Select a cell', () => {
       },
     ]
 
-    locationService.getLocation = jest.fn().mockResolvedValue(Promise.resolve(location))
     prisonerCellAllocationService.getCellsWithCapacity = jest.fn().mockResolvedValue([])
     prisonerCellAllocationService.getPrisonersAtLocations = jest.fn().mockResolvedValue([])
 
@@ -534,10 +503,6 @@ describe('Select a cell', () => {
 
   describe('Cell view model data', () => {
     beforeEach(() => {
-      locationService.getLocation
-        .mockResolvedValueOnce(cellLocationData)
-        .mockResolvedValueOnce(parentLocationData)
-        .mockResolvedValueOnce(superParentLocationData)
       prisonerCellAllocationService.getPrisonersAtLocations = jest.fn().mockResolvedValue([
         { firstName: 'bob', lastName: 'doe', offenderNo: 'A11111' },
         { firstName: 'dave', lastName: 'doe1', offenderNo: 'A22222' },
@@ -851,18 +816,7 @@ describe('Select a cell', () => {
       )
     })
 
-    it('should not request the location prefix when there are no non-associations', async () => {
-      nonAssociationsService.getNonAssociations = jest.fn().mockResolvedValue(null)
-      await controller(req, res)
-
-      expect(locationService.getLocation.mock.calls.length).toBe(0)
-    })
-
     it('should set show non association value to true when there are res unit level non-associations', async () => {
-      locationService.getLocation
-        .mockResolvedValueOnce(cellLocationData)
-        .mockResolvedValueOnce(parentLocationData)
-        .mockResolvedValueOnce(superParentLocationData)
       prisonerCellAllocationService.getCellsWithCapacity = jest.fn().mockResolvedValue([
         {
           id: 1,

--- a/server/controllers/cellMove/selectCell.ts
+++ b/server/controllers/cellMove/selectCell.ts
@@ -84,15 +84,13 @@ const getCellOccupants = async (
 const getResidentialLevelNonAssociations = async (
   res,
   {
-    locationService,
     nonAssociations,
     cellId,
     agencyId,
     location,
   }: {
-    locationService: LocationService
     nonAssociations: OffenderNonAssociationLegacy
-    cellId: number
+    cellId: string
     agencyId: string
     location: string
   },
@@ -106,17 +104,9 @@ const getResidentialLevelNonAssociations = async (
         nonAssociation.offenderNonAssociation.assignedLivingUnitDescription.includes(agencyId),
     )
   }
-  // Get the residential unit level prefix for the selected cell by traversing up the
-  // parent location tree
-  const locationDetail = await locationService.getLocation(res.locals.systemClientToken, cellId)
-  const parentLocationDetail = await locationService.getLocation(
-    res.locals.systemClientToken,
-    locationDetail.parentLocationId,
-  )
-  const { locationPrefix } = await locationService.getLocation(
-    res.locals.systemClientToken,
-    parentLocationDetail.parentLocationId,
-  )
+
+  const [topLevel, firstChild] = cellId.split('-')
+  const locationPrefix = `${topLevel}-${firstChild}`
 
   return nonAssociations.nonAssociations.filter(
     nonAssociation =>
@@ -200,9 +190,8 @@ export default ({
       )
 
       const residentialLevelNonAssociations = await getResidentialLevelNonAssociations(res, {
-        locationService,
         nonAssociations,
-        cellId: hasLength(cells) && cells[0].id,
+        cellId: hasLength(cells) && cells[0].description,
         agencyId: prisonerDetails.agencyId,
         location,
       })

--- a/server/data/locationsInsidePrisonApiClient.test.ts
+++ b/server/data/locationsInsidePrisonApiClient.test.ts
@@ -34,4 +34,32 @@ describe('LocationsInsidePrisonApiClient', () => {
       expect(output).toEqual(response)
     })
   })
+
+  describe('getLocation', () => {
+    it('should return a location from api', async () => {
+      const response = { data: 'data' }
+
+      fakeLocationsInsidePrisonApiClient
+        .get('/locations/key/MDI-1-2-003')
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .reply(200, response)
+
+      const output = await locationsInsidePrisonApiClient.getLocation(accessToken, 'MDI-1-2-003')
+      expect(output).toEqual(response)
+    })
+  })
+
+  describe('getInmatesAtLocation', () => {
+    it('should return occupants from api', async () => {
+      const response = { data: 'data' }
+
+      fakeLocationsInsidePrisonApiClient
+        .get('/prisoner-locations/key/MDI-1-2-003')
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .reply(200, response)
+
+      const output = await locationsInsidePrisonApiClient.getInmatesAtLocation(accessToken, 'MDI-1-2-003')
+      expect(output).toEqual(response)
+    })
+  })
 })

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -1,6 +1,14 @@
 import config from '../config'
 import RestClient from './restClient'
 
+export interface Location {
+  prisonId: string
+  parentId: string
+  key: string
+  pathHierarchy: string
+  capacity: { maxCapacity: number; workingCapacity?: number }
+}
+
 export interface LocationGroup {
   name: string
   key: string
@@ -14,6 +22,18 @@ export interface LocationPrefix {
   locationPrefix: string
 }
 
+export interface Occupant {
+  cellLocation: string
+  prisoners: {
+    prisonerNumber: string
+    firstName: string
+    lastName: string
+    prisonId: string
+    prisonName: string
+    cellLocation: string
+  }[]
+}
+
 export default class LocationsInsidePrisonApiClient {
   constructor() {}
 
@@ -24,6 +44,16 @@ export default class LocationsInsidePrisonApiClient {
   searchGroups(token: string, prisonId: string): Promise<LocationGroup[]> {
     return this.restClient(token).get<LocationGroup[]>({
       path: `/locations/prison/${prisonId}/groups`,
+    })
+  }
+
+  getLocation(token: string, key: string): Promise<Location> {
+    return this.restClient(token).get<Location>({ path: `/locations/key/${key}` })
+  }
+
+  getInmatesAtLocation(token: string, key: string): Promise<Occupant[]> {
+    return this.restClient(token).get<Occupant[]>({
+      path: `/prisoner-locations/key/${key}`,
     })
   }
 }

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -173,20 +173,6 @@ describe('prisonApiClient', () => {
     })
   })
 
-  describe('getLocation', () => {
-    it('should return a location from api', async () => {
-      const response = { data: 'data' }
-
-      fakePrisonApiClient
-        .get('/api/locations/123')
-        .matchHeader('authorization', `Bearer ${accessToken}`)
-        .reply(200, response)
-
-      const output = await prisonApiClient.getLocation(accessToken, 123)
-      expect(output).toEqual(response)
-    })
-  })
-
   describe('getCellsWithCapacity', () => {
     it('should return available cells from api', async () => {
       const response = { data: 'data' }

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -55,20 +55,6 @@ describe('prisonApiClient', () => {
     })
   })
 
-  describe('getInmatesAtLocation', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakePrisonApiClient
-        .get('/api/locations/4231/inmates')
-        .matchHeader('authorization', `Bearer ${accessToken}`)
-        .reply(200, response)
-
-      const output = await prisonApiClient.getInmatesAtLocation(accessToken, 4231)
-      expect(output).toEqual(response)
-    })
-  })
-
   describe('userCaseLoads', () => {
     it('should return data from api', async () => {
       const response = { data: 'data' }

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -394,10 +394,6 @@ export default class PrisonApiClient {
     })
   }
 
-  getLocation(token: string, livingUnitId: number) {
-    return PrisonApiClient.restClient(token).get<Location>({ path: `/api/locations/${livingUnitId}` })
-  }
-
   getCellsWithCapacity(token: string, agencyId: string) {
     return PrisonApiClient.restClient(token, { timeout: { deadline: 30000 } }).get<OffenderCell[]>({
       path: `/api/agencies/${agencyId}/cellsWithCapacity`,

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -347,13 +347,6 @@ export default class PrisonApiClient {
     })
   }
 
-  // Deprecated TODO: Remove this code
-  getInmatesAtLocation(token: string, locationId: number): Promise<Offender[]> {
-    return PrisonApiClient.restClient(token).get<Offender[]>({
-      path: `/api/locations/${locationId}/inmates`,
-    })
-  }
-
   getImage(token: string, imageId: string) {
     return PrisonApiClient.restClient(token).stream({ path: `/api/images/${imageId}/data` })
   }

--- a/server/services/locationService.test.ts
+++ b/server/services/locationService.test.ts
@@ -1,6 +1,7 @@
 import { PrisonApiClient, WhereaboutsApiClient, LocationsInsidePrisonApiClient } from '../data'
-import { Agency, Location, OffenderCell } from '../data/prisonApiClient'
+import { Agency, OffenderCell } from '../data/prisonApiClient'
 import { LocationGroup, LocationPrefix } from '../data/whereaboutsApiClient'
+import { Location, Occupant } from '../data/locationsInsidePrisonApiClient'
 import LocationService from './locationService'
 import { SanitisedError } from '../sanitisedError'
 
@@ -65,32 +66,57 @@ describe('Location service', () => {
 
   describe('getLocation', () => {
     const location: Location = {
-      locationId: 0,
-      locationType: 'string',
-      description: 'string',
-      locationUsage: 'string',
-      agencyId: 'string',
-      parentLocationId: 0,
-      currentOccupancy: 0,
-      locationPrefix: 'string',
-      operationalCapacity: 0,
-      userDescription: 'string',
-      internalLocationCode: 'string',
-      subLocations: true,
+      prisonId: 'ABC',
+      parentId: 'ABC-1',
+      key: 'ABC-1-1-5',
+      pathHierarchy: '1-1-5',
+      capacity: { workingCapacity: 2, maxCapacity: 2 },
     }
 
     it('retrieves location', async () => {
-      prisonApiClient.getLocation.mockResolvedValue(location)
+      locationsInsidePrisonApiClient.getLocation.mockResolvedValue(location)
 
-      const results = await locationService.getLocation(token, 321)
+      const results = await locationService.getLocation(token, 'ABC-1-1-5')
 
       expect(results).toEqual(location)
     })
 
     it('Propagates error', async () => {
-      prisonApiClient.getLocation.mockRejectedValue(new Error('some error'))
+      locationsInsidePrisonApiClient.getLocation.mockRejectedValue(new Error('some error'))
 
-      await expect(locationService.getLocation(token, 321)).rejects.toEqual(new Error('some error'))
+      await expect(locationService.getLocation(token, 'ABC-1-1-5')).rejects.toEqual(new Error('some error'))
+    })
+  })
+
+  describe('getInmatesAtLocation', () => {
+    const occupants: Occupant[] = [
+      {
+        cellLocation: 'ABC-1-1-5',
+        prisoners: [
+          {
+            prisonerNumber: 'A1234AA',
+            firstName: 'Dave',
+            lastName: 'Jones',
+            prisonId: 'LEI',
+            prisonName: 'HMP Leeds',
+            cellLocation: '1-1-5',
+          },
+        ],
+      },
+    ]
+
+    it('retrieves inmates at location', async () => {
+      locationsInsidePrisonApiClient.getInmatesAtLocation.mockResolvedValue(occupants)
+
+      const results = await locationService.getInmatesAtLocation(token, 'ABC-1-1-5')
+
+      expect(results).toEqual(occupants)
+    })
+
+    it('Propagates error', async () => {
+      locationsInsidePrisonApiClient.getInmatesAtLocation.mockRejectedValue(new Error('some error'))
+
+      await expect(locationService.getInmatesAtLocation(token, 'ABC-1-1-5')).rejects.toEqual(new Error('some error'))
     })
   })
 

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -1,6 +1,6 @@
 import { PrisonApiClient, WhereaboutsApiClient, LocationsInsidePrisonApiClient } from '../data'
-import { Agency, Location, OffenderCell } from '../data/prisonApiClient'
-import { LocationGroup, LocationPrefix } from '../data/locationsInsidePrisonApiClient'
+import { Agency, OffenderCell } from '../data/prisonApiClient'
+import { Location, LocationGroup, LocationPrefix, Occupant } from '../data/locationsInsidePrisonApiClient'
 
 export default class LocationService {
   constructor(
@@ -16,8 +16,12 @@ export default class LocationService {
     )
   }
 
-  async getLocation(token: string, livingUnitId: number): Promise<Location> {
-    return await this.prisonApiClient.getLocation(token, livingUnitId)
+  async getLocation(token: string, key: string): Promise<Location> {
+    return await this.locationsInsidePrisonApiClient.getLocation(token, key)
+  }
+
+  async getInmatesAtLocation(token: string, locationId: string): Promise<Occupant[]> {
+    return await this.locationsInsidePrisonApiClient.getInmatesAtLocation(token, locationId)
   }
 
   async getAttributesForLocation(token: string, locationId: number): Promise<OffenderCell> {

--- a/server/services/prisonerCellAllocationService.test.ts
+++ b/server/services/prisonerCellAllocationService.test.ts
@@ -70,41 +70,6 @@ describe('Prisoner cell allocation service', () => {
     })
   })
 
-  describe('getInmatesAtLocation', () => {
-    const offenders: Offender[] = [
-      {
-        bookingId: 1,
-        offenderNo: 'A1234BC',
-        firstName: 'JOHN',
-        lastName: 'SMITH',
-        dateOfBirth: '1990-10-12',
-        age: 29,
-        agencyId: 'MDI',
-        assignedLivingUnitId: 1,
-        assignedLivingUnitDesc: 'UNIT-1',
-        categoryCode: 'C',
-        alertsDetails: ['XA', 'XVL'],
-        alertsCodes: ['XA', 'XVL'],
-      },
-    ]
-
-    it('Retrieves inmates at location', async () => {
-      prisonApiClient.getInmatesAtLocation.mockResolvedValue(offenders)
-
-      const result = await prisonerCellAllocationService.getInmatesAtLocation(token, 4231)
-
-      expect(result[0].offenderNo).toEqual('A1234BC')
-    })
-
-    it('Propagates error', async () => {
-      prisonApiClient.getInmatesAtLocation.mockRejectedValue(new Error('some error'))
-
-      await expect(prisonerCellAllocationService.getInmatesAtLocation(token, 4231)).rejects.toEqual(
-        new Error('some error'),
-      )
-    })
-  })
-
   describe('getPrisonersAtLocations', () => {
     const prisoners: Prisoner[] = [
       {

--- a/server/services/prisonerCellAllocationService.ts
+++ b/server/services/prisonerCellAllocationService.ts
@@ -18,11 +18,6 @@ export default class PrisonerCellAllocationService {
     return await this.prisonApiClient.getInmates(token, locationId, keywords, returnAlerts)
   }
 
-  // Deprecated TODO: Remove this code and update all controllers to use getPrisonersAtLocations instead
-  async getInmatesAtLocation(token: string, locationId: number) {
-    return await this.prisonApiClient.getInmatesAtLocation(token, locationId)
-  }
-
   async getPrisonersAtLocations(token: string, agencyId, locationDescriptions: string[]) {
     const result = await this.prisonerSearchApiClient.getPrisonersAtLocations(token, agencyId, locationDescriptions)
     return result.content

--- a/server/views/cellMove/selectCell.njk
+++ b/server/views/cellMove/selectCell.njk
@@ -68,7 +68,7 @@
   {% endif %}
 
   {% if index === 1 %}
-     <td class="{{ cellClass }}"><a href="{{ '/prisoner/' + offenderNo + '/cell-move/consider-risks?cellId=' + cell.id }}" class="govuk-link">Select cell</a></td>
+     <td class="{{ cellClass }}"><a href="{{ '/prisoner/' + offenderNo + '/cell-move/consider-risks?cellId=' + cell.description }}" class="govuk-link">Select cell</a></td>
   {% else %}
       <td class="{{ cellClass }}">
       </td>


### PR DESCRIPTION
This code is the first of a series of changes to phase out calls to prisonApi in favour of the new locationsInsideprisonApi. The code below replaces the call to   prisonApi  /api/locations/{locationId} which gets location data, with a call to the new locationsInsidePrisonApi /locations/key/{key}

**The cellId passed as a query string has changed from the nomisId to the string representation of cell location**

prisonApi calls rely on an integer value for the location id. However locationsInsidePrisonApi has no mapping with that integer value so we've decided to use the /locations/key/{key} endpoint which uses the location value like MDI-A-1-1.
Using the location string value like MDI-1-1-1 has a knock on impact across many pages. The id (cellId) is passed between pages as a query string. 
The prisonerCellAllocationService's getInmatesAtLocation() also required the nomis integer version of the id so will no longer work. Consequently getting the inmates at location is now handled by the locationsInsidePrisonApi.getInmatesAtLocation()

