### PR TITLE
MAP-1350 move getInmatesAtLocation() to a more appropriate service

### DIFF
--- a/server/controllers/cellMove/cellMoveHistory.test.ts
+++ b/server/controllers/cellMove/cellMoveHistory.test.ts
@@ -12,7 +12,9 @@ jest.mock('../../services/prisonerDetailsService')
 
 describe('Cell move history', () => {
   const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
   const userService = jest.mocked(new UserService(undefined, undefined))
 

--- a/server/controllers/cellMove/cellMovePrisonerSearch.test.ts
+++ b/server/controllers/cellMove/cellMovePrisonerSearch.test.ts
@@ -5,7 +5,9 @@ import prisonerSearchController from './cellMovePrisonerSearch'
 jest.mock('../../services/prisonerCellAllocationService')
 
 describe('Prisoner search', () => {
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
 
   let req
   let res

--- a/server/controllers/cellMove/cellMoveTemporaryMove.test.ts
+++ b/server/controllers/cellMove/cellMoveTemporaryMove.test.ts
@@ -4,7 +4,9 @@ import PrisonerCellAllocationService from '../../services/prisonerCellAllocation
 jest.mock('../../services/prisonerCellAllocationService')
 
 describe('Move someone temporarily out of a cell', () => {
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
 
   let req
   let res

--- a/server/controllers/cellMove/cellMoveViewResidentialLocation.test.ts
+++ b/server/controllers/cellMove/cellMoveViewResidentialLocation.test.ts
@@ -7,7 +7,9 @@ jest.mock('../../services/prisonerCellAllocationService')
 
 describe('View Residential Location', () => {
   const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
 
   let req
   let res

--- a/server/controllers/cellMove/confirmCellMove.test.ts
+++ b/server/controllers/cellMove/confirmCellMove.test.ts
@@ -14,7 +14,9 @@ jest.mock('../../services/prisonerDetailsService')
 describe('Change cell play back details', () => {
   const analyticsService = jest.mocked(new AnalyticsService(undefined))
   const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 
   let controller

--- a/server/controllers/cellMove/confirmReceptionMove.test.ts
+++ b/server/controllers/cellMove/confirmReceptionMove.test.ts
@@ -9,7 +9,9 @@ jest.mock('../../services/prisonerCellAllocationService')
 jest.mock('../../services/prisonerDetailsService')
 
 describe('Confirm reception move', () => {
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 
   logger.info = jest.fn()

--- a/server/controllers/cellMove/considerRisks.ts
+++ b/server/controllers/cellMove/considerRisks.ts
@@ -11,6 +11,7 @@ import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import NonAssociationsService from '../../services/nonAssociationsService'
 import logger from '../../../logger'
 import config from '../../config'
+import PrisonerCellAllocationService from '../../services/prisonerCellAllocationService'
 
 const activeCellMoveAlertsExcludingDisabled = alert =>
   !alert.expired && cellMoveAlertCodes.includes(alert.alertCode) && alert.alertCode !== 'PEEP'
@@ -22,9 +23,16 @@ type Params = {
   locationService: LocationService
   prisonerDetailsService: PrisonerDetailsService
   nonAssociationsService: NonAssociationsService
+  prisonerCellAllocationService: PrisonerCellAllocationService
 }
 
-export default ({ analyticsService, locationService, nonAssociationsService, prisonerDetailsService }: Params) => {
+export default ({
+  analyticsService,
+  locationService,
+  nonAssociationsService,
+  prisonerDetailsService,
+  prisonerCellAllocationService,
+}: Params) => {
   const getOccupantsDetails = async (context, offenders) =>
     Promise.all(offenders.map(offender => prisonerDetailsService.getDetails(context, offender, true)))
 
@@ -45,7 +53,7 @@ export default ({ analyticsService, locationService, nonAssociationsService, pri
     try {
       const [currentOffenderDetails, occupants] = await Promise.all([
         prisonerDetailsService.getDetails(systemClientToken, offenderNo, true),
-        locationService.getInmatesAtLocation(systemClientToken, cellId),
+        prisonerCellAllocationService.getInmatesAtLocation(systemClientToken, cellId),
       ])
       const hasOccupants = occupants.length > 0
       const currentOccupants = occupants.flatMap(occupant => occupant.prisoners)
@@ -227,7 +235,7 @@ export default ({ analyticsService, locationService, nonAssociationsService, pri
 
       const [currentOffenderDetails, occupants] = await Promise.all([
         prisonerDetailsService.getDetails(systemClientToken, offenderNo, true),
-        locationService.getInmatesAtLocation(systemClientToken, cellId),
+        prisonerCellAllocationService.getInmatesAtLocation(systemClientToken, cellId),
       ])
 
       const currentOccupants = occupants.flatMap(occupant => occupant.prisoners)

--- a/server/controllers/cellMove/considerRisksReception.test.ts
+++ b/server/controllers/cellMove/considerRisksReception.test.ts
@@ -81,7 +81,9 @@ const prisonerDetails = {
 
 describe('Consider risks reception', () => {
   const nonAssociationsService = jest.mocked(new NonAssociationsService(undefined))
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 
   beforeEach(() => {

--- a/server/controllers/cellMove/recentCellMoves.test.ts
+++ b/server/controllers/cellMove/recentCellMoves.test.ts
@@ -48,7 +48,9 @@ const dataSets = {
 }
 
 describe('Recent cell moves', () => {
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
 
   let controller
   let req

--- a/server/controllers/cellMove/selectCell.test.ts
+++ b/server/controllers/cellMove/selectCell.test.ts
@@ -18,7 +18,9 @@ const someAgency = 'LEI'
 describe('Select a cell', () => {
   const locationService = jest.mocked(new LocationService(undefined, undefined, undefined))
   const nonAssociationsService = jest.mocked(new NonAssociationsService(undefined))
-  const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const prisonerCellAllocationService = jest.mocked(
+    new PrisonerCellAllocationService(undefined, undefined, undefined, undefined),
+  )
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined))
 
   let controller

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -26,6 +26,7 @@ export const services = () => {
     prisonApiClient,
     whereaboutsApiClient,
     prisonerSearchApiClient,
+    locationsInsidePrisonApiClient,
   )
   const prisonerDetailsService = new PrisonerDetailsService(prisonApiClient)
   const locationService = new LocationService(prisonApiClient, whereaboutsApiClient, locationsInsidePrisonApiClient)

--- a/server/services/locationService.test.ts
+++ b/server/services/locationService.test.ts
@@ -1,7 +1,7 @@
 import { PrisonApiClient, WhereaboutsApiClient, LocationsInsidePrisonApiClient } from '../data'
 import { Agency, OffenderCell } from '../data/prisonApiClient'
 import { LocationGroup, LocationPrefix } from '../data/whereaboutsApiClient'
-import { Location, Occupant } from '../data/locationsInsidePrisonApiClient'
+import { Location } from '../data/locationsInsidePrisonApiClient'
 import LocationService from './locationService'
 import { SanitisedError } from '../sanitisedError'
 
@@ -85,38 +85,6 @@ describe('Location service', () => {
       locationsInsidePrisonApiClient.getLocation.mockRejectedValue(new Error('some error'))
 
       await expect(locationService.getLocation(token, 'ABC-1-1-5')).rejects.toEqual(new Error('some error'))
-    })
-  })
-
-  describe('getInmatesAtLocation', () => {
-    const occupants: Occupant[] = [
-      {
-        cellLocation: 'ABC-1-1-5',
-        prisoners: [
-          {
-            prisonerNumber: 'A1234AA',
-            firstName: 'Dave',
-            lastName: 'Jones',
-            prisonId: 'LEI',
-            prisonName: 'HMP Leeds',
-            cellLocation: '1-1-5',
-          },
-        ],
-      },
-    ]
-
-    it('retrieves inmates at location', async () => {
-      locationsInsidePrisonApiClient.getInmatesAtLocation.mockResolvedValue(occupants)
-
-      const results = await locationService.getInmatesAtLocation(token, 'ABC-1-1-5')
-
-      expect(results).toEqual(occupants)
-    })
-
-    it('Propagates error', async () => {
-      locationsInsidePrisonApiClient.getInmatesAtLocation.mockRejectedValue(new Error('some error'))
-
-      await expect(locationService.getInmatesAtLocation(token, 'ABC-1-1-5')).rejects.toEqual(new Error('some error'))
     })
   })
 

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -1,6 +1,6 @@
 import { PrisonApiClient, WhereaboutsApiClient, LocationsInsidePrisonApiClient } from '../data'
 import { Agency, OffenderCell } from '../data/prisonApiClient'
-import { Location, LocationGroup, LocationPrefix, Occupant } from '../data/locationsInsidePrisonApiClient'
+import { Location, LocationGroup, LocationPrefix } from '../data/locationsInsidePrisonApiClient'
 
 export default class LocationService {
   constructor(
@@ -18,10 +18,6 @@ export default class LocationService {
 
   async getLocation(token: string, key: string): Promise<Location> {
     return await this.locationsInsidePrisonApiClient.getLocation(token, key)
-  }
-
-  async getInmatesAtLocation(token: string, locationId: string): Promise<Occupant[]> {
-    return await this.locationsInsidePrisonApiClient.getInmatesAtLocation(token, locationId)
   }
 
   async getAttributesForLocation(token: string, locationId: number): Promise<OffenderCell> {

--- a/server/services/prisonerCellAllocationService.ts
+++ b/server/services/prisonerCellAllocationService.ts
@@ -1,7 +1,8 @@
-import { PrisonApiClient, WhereaboutsApiClient } from '../data'
+import { PrisonApiClient, WhereaboutsApiClient, LocationsInsidePrisonApiClient } from '../data'
 import { Alert, Offender, OffenderInReception } from '../data/prisonApiClient'
 import logger from '../../logger'
 import PrisonerSearchApiClient from '../data/prisonerSearchApiClient'
+import { Occupant } from '../data/locationsInsidePrisonApiClient'
 
 export interface OffenderWithAlerts extends OffenderInReception {
   alerts?: string[]
@@ -12,10 +13,15 @@ export default class PrisonerCellAllocationService {
     private readonly prisonApiClient: PrisonApiClient,
     private readonly whereaboutsApiClient: WhereaboutsApiClient,
     private readonly prisonerSearchApiClient: PrisonerSearchApiClient,
+    private readonly locationsInsidePrisonApiClient: LocationsInsidePrisonApiClient,
   ) {}
 
   async getInmates(token: string, locationId: string, keywords?: string, returnAlerts?: boolean): Promise<Offender[]> {
     return await this.prisonApiClient.getInmates(token, locationId, keywords, returnAlerts)
+  }
+
+  async getInmatesAtLocation(token: string, locationId: string): Promise<Occupant[]> {
+    return await this.locationsInsidePrisonApiClient.getInmatesAtLocation(token, locationId)
   }
 
   async getPrisonersAtLocations(token: string, agencyId, locationDescriptions: string[]) {


### PR DESCRIPTION
moving getInmatesAtLocation() to the prisonerCellAllocationService module as per the PR comments on [this](https://github.com/ministryofjustice/hmpps-change-someones-cell/pull/73)