### PR TITLE
MAP-1350 remove call to prisonApiClient.getAttributesForLocation 

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -73,7 +73,6 @@ export default defineConfig({
         stubCellMoveTypes: type => prisonApi.stubCellMoveTypes(type),
         stubMoveToCell: () => whereabouts.stubMoveToCell(),
         stubMoveToCellSwap: () => prisonApi.stubMoveToCellSwap(),
-        stubAttributesForLocation: locationAttributes => prisonApi.stubAttributesForLocation(locationAttributes),
         verifyMoveToCell: body => whereabouts.verifyMoveToCell(body),
         verifyMoveToCellSwap: ({ bookingId }) => prisonApi.verifyMoveToCellSwap({ bookingId }),
         stubAgencyDetails: ({ agencyId, details }) => Promise.all([prisonApi.stubAgencyDetails(agencyId, details)]),

--- a/integration_tests/e2e/confirmCellMove.cy.ts
+++ b/integration_tests/e2e/confirmCellMove.cy.ts
@@ -32,9 +32,6 @@ context('A user can confirm the cell move', () => {
     })
     cy.task('stubMoveToCell')
     cy.task('stubMoveToCellSwap')
-    cy.task('stubAttributesForLocation', {
-      capacity: 2,
-    })
     cy.task('stubCellMoveTypes', [
       {
         code: 'ADM',

--- a/integration_tests/e2e/spaceCreated.cy.ts
+++ b/integration_tests/e2e/spaceCreated.cy.ts
@@ -21,9 +21,7 @@ context('A user get confirmation of a cell move', () => {
       locationId: 1,
       locationData: { parentLocationId: 2, description: 'MDI-1-1', locationPrefix: 'MDI-1' },
     })
-    cy.task('stubAttributesForLocation', {
-      capacity: 2,
-    })
+
     cy.task('stubMoveToCell')
   })
 

--- a/integration_tests/mockApis/prisonApi.ts
+++ b/integration_tests/mockApis/prisonApi.ts
@@ -318,21 +318,6 @@ export const stubMoveToCellSwap = () =>
     },
   })
 
-export const stubAttributesForLocation = locationAttributes =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPathPattern: '/api/cell/[0-9]+?/attributes',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: locationAttributes || {},
-    },
-  })
-
 export const verifyMoveToCellSwap = ({ bookingId }) => verifyPut(`/api/bookings/${bookingId}/move-to-cell-swap`)
 
 export const stubAgencyDetails = (agencyId, details, status = 200) =>
@@ -464,7 +449,6 @@ export default {
   stubBookingDetails,
   stubCellMoveTypes,
   stubMoveToCellSwap,
-  stubAttributesForLocation,
   verifyMoveToCellSwap,
   stubAgencyDetails,
   stubCellMoveHistory,

--- a/server/controllers/cellMove/confirmCellMove.test.ts
+++ b/server/controllers/cellMove/confirmCellMove.test.ts
@@ -74,7 +74,6 @@ describe('Change cell play back details', () => {
       },
     })
 
-    locationService.getAttributesForLocation = jest.fn().mockResolvedValue({ capacity: 1 })
     prisonerCellAllocationService.getCellMoveReasonTypes = jest.fn().mockResolvedValue([])
 
     analyticsService.sendEvents = jest.fn().mockResolvedValue(Promise.resolve({}))

--- a/server/data/prisonApiClient.test.ts
+++ b/server/data/prisonApiClient.test.ts
@@ -188,20 +188,6 @@ describe('prisonApiClient', () => {
     })
   })
 
-  describe('getAttributesForLocation', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakePrisonApiClient
-        .get('/api/cell/123/attributes')
-        .matchHeader('authorization', `Bearer ${accessToken}`)
-        .reply(200, response)
-
-      const output = await prisonApiClient.getAttributesForLocation(accessToken, 123)
-      expect(output).toEqual(response)
-    })
-  })
-
   describe('moveToCellSwap', () => {
     it('should request the move to cell swap', async () => {
       const response = { data: 'data' }

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -402,12 +402,6 @@ export default class PrisonApiClient {
     })
   }
 
-  getAttributesForLocation(token: string, locationId: number) {
-    return PrisonApiClient.restClient(token).get<OffenderCell>({
-      path: `/api/cell/${locationId}/attributes`,
-    })
-  }
-
   moveToCellSwap(token: string, bookingId: number) {
     return PrisonApiClient.restClient(token).put<OffenderDetails>({
       path: `/api/bookings/${bookingId}/move-to-cell-swap`,

--- a/server/services/locationService.test.ts
+++ b/server/services/locationService.test.ts
@@ -1,5 +1,5 @@
 import { PrisonApiClient, WhereaboutsApiClient, LocationsInsidePrisonApiClient } from '../data'
-import { Agency, OffenderCell } from '../data/prisonApiClient'
+import { Agency } from '../data/prisonApiClient'
 import { LocationGroup, LocationPrefix } from '../data/whereaboutsApiClient'
 import { Location } from '../data/locationsInsidePrisonApiClient'
 import LocationService from './locationService'
@@ -85,36 +85,6 @@ describe('Location service', () => {
       locationsInsidePrisonApiClient.getLocation.mockRejectedValue(new Error('some error'))
 
       await expect(locationService.getLocation(token, 'ABC-1-1-5')).rejects.toEqual(new Error('some error'))
-    })
-  })
-
-  describe('getAttributesForLocation', () => {
-    const cell: OffenderCell = {
-      id: 6352,
-      description: 'LEI-1-1',
-      userDescription: 'LEI-1-1',
-      capacity: 2,
-      noOfOccupants: 2,
-      attributes: [
-        {
-          code: 'LC',
-          description: 'Listener Cell',
-        },
-      ],
-    }
-
-    it('retrieves location', async () => {
-      prisonApiClient.getAttributesForLocation.mockResolvedValue(cell)
-
-      const results = await locationService.getAttributesForLocation(token, 6352)
-
-      expect(results).toEqual(cell)
-    })
-
-    it('Propagates error', async () => {
-      prisonApiClient.getAttributesForLocation.mockRejectedValue(new Error('some error'))
-
-      await expect(locationService.getAttributesForLocation(token, 6352)).rejects.toEqual(new Error('some error'))
     })
   })
 

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -1,5 +1,5 @@
 import { PrisonApiClient, WhereaboutsApiClient, LocationsInsidePrisonApiClient } from '../data'
-import { Agency, OffenderCell } from '../data/prisonApiClient'
+import { Agency } from '../data/prisonApiClient'
 import { Location, LocationGroup, LocationPrefix } from '../data/locationsInsidePrisonApiClient'
 
 export default class LocationService {

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -20,10 +20,6 @@ export default class LocationService {
     return await this.locationsInsidePrisonApiClient.getLocation(token, key)
   }
 
-  async getAttributesForLocation(token: string, locationId: number): Promise<OffenderCell> {
-    return await this.prisonApiClient.getAttributesForLocation(token, locationId)
-  }
-
   async getAgencyGroupLocationPrefix(token: string, agencyId: string, groupName: string): Promise<LocationPrefix> {
     try {
       return await this.whereaboutsApiClient.getAgencyGroupLocationPrefix(token, agencyId, groupName)


### PR DESCRIPTION
call to locationService.getAttributesForLocation() and hence prisonApi.getAttributesForLocation() has already been removed [see this line 102 of server/controllers/cellMove/confirmCellMove.ts](https://github.com/ministryofjustice/hmpps-change-someones-cell/pull/73) , but the actual methods and tests were not. This code change is to remove those dangling functions too. 
