### PR TITLE
MAP-1403 refactor implementation of latest govuk-frontend dependency

### DIFF
--- a/assets/js/govukFrontendInit.js
+++ b/assets/js/govukFrontendInit.js
@@ -1,0 +1,3 @@
+import { initAll } from '/assets/govuk/govuk-frontend.min.js'
+
+initAll()

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,4 +1,0 @@
-import * as govukFrontend from 'node_modules/govuk-frontend/dist/govuk/all'
-import * as mojFrontend from '@ministryofjustice/frontend'
-govukFrontend.initAll()
-mojFrontend.initAll()

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "husky install",
     "copy-views": "cp -R server/views dist/server/",
-    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend --load-path=node_modules/govuk_frontend_toolkit/stylesheets --load-path=node_modules/govuk-elements-sass/public/sass --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css --style compressed",
+    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend/dist --load-path=node_modules/@ministryofjustice/frontend --load-path=node_modules/govuk_frontend_toolkit/stylesheets --load-path=node_modules/govuk-elements-sass/public/sass --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css --style compressed",
     "watch-ts": "tsc -w",
     "watch-views": "nodemon --watch server/views -e html,njk -x npm run copy-views",
     "watch-node": "DEBUG=gov-starter-server* nodemon -r dotenv/config --watch dist/ dist/server.js | bunyan -o short",

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -32,7 +32,9 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
     [
       path.join(__dirname, '../../server/views'),
       'node_modules/govuk-frontend/dist/',
+      'node_modules/govuk-frontend/dist/components/',
       'node_modules/@ministryofjustice/frontend/',
+      'node_modules/@ministryofjustice/frontend/moj/components/',
     ],
     {
       autoescape: true,

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -86,7 +86,7 @@
 {% block bodyEnd %}
   {# Run JavaScript at end of the
   <body>, to avoid blocking the initial render. #}
-  <script src="/js/index.js"></script>
+  <script type="module" src="/assets/govukFrontendInit.js"></script>
   <script src="/assets/moj/all.js"></script>
   {% block pageScripts %}
   {%  endblock %}


### PR DESCRIPTION
changes made to how the govuk-frontend is implemented and to be be inline with other projects (specifically [this](https://github.com/ministryofjustice/hmpps-prisoner-profile/pull/416)) rather the typescript template project. This is because the template project also introduces changes to the build process including using the esbuild module. Implementing these build changes to be done as a separate ticket
