### PR TITLE
MAP-1414 Replace maxCapacity with actualCapacity in cell selection

### DIFF
--- a/integration_tests/e2e/selectCell.cy.ts
+++ b/integration_tests/e2e/selectCell.cy.ts
@@ -142,7 +142,7 @@ context('A user can select a cell', () => {
       const page = SelectCellPage.goTo(offenderNo)
 
       page.cellResults().then($table => {
-        cy.get($table).find('tr').its('length').should('eq', 3)
+        cy.get($table).find('tr').its('length').should('eq', 2)
         cy.get($table)
           .find('tr')
           .then($tableRows => {
@@ -157,17 +157,6 @@ context('A user can select a cell', () => {
               csra: 'Standard\n\nView details\nfor Doe, Bob',
               relevantAlerts: 'PEEP',
               selectCell: 'Select cell',
-            })
-
-            assertRow(1, columns, {
-              location: '',
-              cellType: '',
-              capacity: '',
-              spaces: '',
-              occupier: 'Mcbubblesworth, Horatio\nView details\nfor Mcbubblesworth, Horatio\nNON-ASSOCIATION',
-              csra: 'Not entered\n\nView details\nfor Mcbubblesworth, Horatio',
-              relevantAlerts: '',
-              selectCell: '',
             })
           })
       })

--- a/server/controllers/cellMove/confirmCellMove.ts
+++ b/server/controllers/cellMove/confirmCellMove.ts
@@ -7,6 +7,7 @@ import PrisonerDetailsService from '../../services/prisonerDetailsService'
 import { properCaseName, putLastNameFirst } from '../../utils'
 import { getConfirmBackLinkData } from './cellMoveUtils'
 import { ReferenceCode } from '../../data/prisonApiClient'
+import { getActualCapacity } from '../../data/locationsInsidePrisonApiClient'
 
 const CSWAP = 'C-SWAP'
 
@@ -104,7 +105,7 @@ export default ({
   const makeCellMove = async (req, res, { cellId, bookingId, agencyId, offenderNo, reasonCode, commentText }) => {
     const { systemClientToken } = res.locals
     const { capacity, key, pathHierarchy } = await locationService.getLocation(systemClientToken, cellId)
-    const actualCapacity = capacity.workingCapacity || capacity.maxCapacity
+    const actualCapacity = getActualCapacity(capacity)
     try {
       await prisonerCellAllocationService.moveToCell(
         systemClientToken,

--- a/server/controllers/cellMove/selectCell.test.ts
+++ b/server/controllers/cellMove/selectCell.test.ts
@@ -494,7 +494,7 @@ describe('Select a cell', () => {
                     typeDescription: 'Listener Cell',
                   },
                 ],
-                maxCapacity: 1,
+                actualCapacity: 1,
                 occupants: [],
                 spaces: 1,
               },
@@ -516,7 +516,7 @@ describe('Select a cell', () => {
             cells: [
               {
                 key: 'MDI-1-2',
-                maxCapacity: 2,
+                actualCapacity: 2,
                 occupants: [],
                 spaces: 2,
                 type: [
@@ -660,7 +660,7 @@ describe('Select a cell', () => {
           cells: [
             {
               key: 'MDI-1-1-3',
-              maxCapacity: 2,
+              actualCapacity: 2,
               occupants: [
                 {
                   alerts: [
@@ -698,7 +698,7 @@ describe('Select a cell', () => {
             },
             {
               key: 'MDI-1-1-2',
-              maxCapacity: 2,
+              actualCapacity: 2,
               occupants: [
                 {
                   alerts: [
@@ -736,7 +736,7 @@ describe('Select a cell', () => {
             },
             {
               key: 'MDI-1-1-1',
-              maxCapacity: 2,
+              actualCapacity: 2,
               occupants: [
                 {
                   alerts: [
@@ -868,7 +868,7 @@ describe('Select a cell', () => {
           cells: [
             {
               key: 'LEI-1-1-1',
-              maxCapacity: 4,
+              actualCapacity: 4,
               occupants: [
                 {
                   alerts: [],

--- a/server/controllers/cellMove/selectCell.ts
+++ b/server/controllers/cellMove/selectCell.ts
@@ -184,16 +184,18 @@ export default ({
         showNonAssociationsLink: numberOfNonAssociations > 0,
         alerts: alertsToShow,
         showNonAssociationWarning: Boolean(residentialLevelNonAssociations.length),
-        cells: selectedCells?.map(cell => {
-          const actualCapacity = getActualCapacity(cell)
-          return {
-            key: cell.key,
-            type: hasLength(cell.legacyAttributes) && cell.legacyAttributes.sort(),
-            actualCapacity,
-            spaces: actualCapacity - cell.noOfOccupants,
-            occupants: getCellOccupants({ prisonersInCell: cell.prisonersInCell, nonAssociations }),
-          }
-        }),
+        cells: selectedCells
+          ?.filter(cell => cell.pathHierarchy !== prisonerDetails.cellLocation)
+          .map(cell => {
+            const actualCapacity = getActualCapacity(cell)
+            return {
+              key: cell.key,
+              type: hasLength(cell.legacyAttributes) && cell.legacyAttributes.sort(),
+              actualCapacity,
+              spaces: actualCapacity - cell.noOfOccupants,
+              occupants: getCellOccupants({ prisonersInCell: cell.prisonersInCell, nonAssociations }),
+            }
+          }),
         locations: renderLocationOptions(locationsData),
         subLocations,
         cellAttributes,

--- a/server/controllers/cellMove/selectCell.ts
+++ b/server/controllers/cellMove/selectCell.ts
@@ -15,6 +15,7 @@ import LocationService from '../../services/locationService'
 import { PrisonerNonAssociation } from '../../data/nonAssociationsApiClient'
 import config from '../../config'
 import { Prisoner } from '../../data/prisonerSearchApiClient'
+import { getActualCapacity } from '../../data/locationsInsidePrisonApiClient'
 
 const defaultSubLocationsValue = { text: 'Select area in residential unit', value: '' }
 const noAreasSelectedDropDownValue = { text: 'No areas to select', value: '' }
@@ -156,8 +157,9 @@ export default ({
       })
 
       const selectedCells = cells.filter(cell => {
-        if (cellType === 'SO') return cell.maxCapacity === 1
-        if (cellType === 'MO') return cell.maxCapacity > 1
+        const actualCapacity = getActualCapacity(cell)
+        if (cellType === 'SO') return actualCapacity === 1
+        if (cellType === 'MO') return actualCapacity > 1
         return cell
       })
 
@@ -182,13 +184,16 @@ export default ({
         showNonAssociationsLink: numberOfNonAssociations > 0,
         alerts: alertsToShow,
         showNonAssociationWarning: Boolean(residentialLevelNonAssociations.length),
-        cells: selectedCells?.map(cell => ({
-          key: cell.key,
-          type: hasLength(cell.legacyAttributes) && cell.legacyAttributes.sort(),
-          maxCapacity: cell.maxCapacity,
-          spaces: cell.maxCapacity - cell.noOfOccupants,
-          occupants: getCellOccupants({ prisonersInCell: cell.prisonersInCell, nonAssociations }),
-        })),
+        cells: selectedCells?.map(cell => {
+          const actualCapacity = getActualCapacity(cell)
+          return {
+            key: cell.key,
+            type: hasLength(cell.legacyAttributes) && cell.legacyAttributes.sort(),
+            actualCapacity,
+            spaces: actualCapacity - cell.noOfOccupants,
+            occupants: getCellOccupants({ prisonersInCell: cell.prisonersInCell, nonAssociations }),
+          }
+        }),
         locations: renderLocationOptions(locationsData),
         subLocations,
         cellAttributes,

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -2,12 +2,19 @@ import config from '../config'
 import RestClient from './restClient'
 import { Prisoner } from './prisonerSearchApiClient'
 
+export interface Capacity {
+  workingCapacity?: number
+  maxCapacity: number
+}
+
+export const getActualCapacity = (capacity: Capacity) => capacity.workingCapacity || capacity.maxCapacity
+
 export interface Location {
   prisonId: string
   parentId: string
   key: string
   pathHierarchy: string
-  capacity: { maxCapacity: number; workingCapacity?: number }
+  capacity: Capacity
 }
 
 export interface CellLocation {

--- a/server/views/cellMove/selectCell.njk
+++ b/server/views/cellMove/selectCell.njk
@@ -15,7 +15,7 @@
   {% if index === 1 %}
     <td class="{{ cellClass }}">{{ cell.key }}</th>
     <td class="{{ cellClass }}">{{ cell.type | join(',<br>', 'typeDescription') | safe if cell.type.length else 'Nothing entered' }}</td>
-    <td class="{{ cellClass }}">{{ cell.maxCapacity }}</td>
+    <td class="{{ cellClass }}">{{ cell.actualCapacity }}</td>
     <td class="{{ cellClass }}">{{ cell.spaces }}</td>
   {% else %}
     <td class="{{ cellClass }}">


### PR DESCRIPTION
- Updates the cell selection process to prefer 'actualCapacity', which considers both 'workingCapacity' and 'maxCapacity', over 'maxCapacity' alone. This makes sure that any operational changes to cell capacity are reflected in selection process. The updates were made in the relevant controller, view, and test files.
- Introduces a filter in the selection of cells to exclude the current cell of the prisoner. Previously, the selectedCells array included the prisoner's own cell, which is not necessary as the purpose is to find potential cells to move the prisoner to, excluding their current one. This not only delivers a more accurate list of cells but also reduces the potential for user selection errors.
