### PR TITLE
MAP-1866 fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ARG GIT_REF
 ARG GIT_BRANCH
 
 RUN apt-get update && \
-        apt-get install -y make python g++
+        apt-get install -y make python-is-python3 2to3
 
 COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit


### PR DESCRIPTION
Previous PR to update Node to v22 failed at build-docker stage because the python install and build wasn't correct. 
Error suggested using   python-is-python3 2to3

<img width="1187" alt="Screenshot 2024-11-21 at 10 12 49" src="https://github.com/user-attachments/assets/a616da0e-ad82-4504-a2c3-fee722480bcd">

