### PR TITLE
MAP-2396: Add consider risk and cell move metrics to app insights

### DIFF
--- a/server/controllers/cellMove/confirmCellMove.ts
+++ b/server/controllers/cellMove/confirmCellMove.ts
@@ -8,6 +8,8 @@ import { properCaseName, putLastNameFirst } from '../../utils'
 import { getConfirmBackLinkData } from './cellMoveUtils'
 import { ReferenceCode } from '../../data/prisonApiClient'
 import { getActualCapacity } from '../../data/locationsInsidePrisonApiClient'
+import MetricsEvent from '../../data/metricsEvent'
+import MetricsService from '../../services/metricsService'
 
 const CSWAP = 'C-SWAP'
 
@@ -34,6 +36,7 @@ type Params = {
   locationService: LocationService
   prisonerCellAllocationService: PrisonerCellAllocationService
   prisonerDetailsService: PrisonerDetailsService
+  metricsService: MetricsService
 }
 
 export default ({
@@ -41,6 +44,7 @@ export default ({
   locationService,
   prisonerCellAllocationService,
   prisonerDetailsService,
+  metricsService,
 }: Params) => {
   const index = async (req, res) => {
     const { offenderNo } = req.params
@@ -100,6 +104,9 @@ export default ({
       .catch(_reason => {
         logger.warn('Failed to send Google Analytics event')
       })
+
+    const event = MetricsEvent.CELL_MOVE_EVENT(agencyId, cellType)
+    metricsService.trackEvent(event)
   }
 
   const makeCellMove = async (req, res, { cellId, bookingId, agencyId, offenderNo, reasonCode, commentText }) => {

--- a/server/controllers/cellMove/considerRisks.test.ts
+++ b/server/controllers/cellMove/considerRisks.test.ts
@@ -8,6 +8,8 @@ import PrisonerCellAllocationService from '../../services/prisonerCellAllocation
 
 import config from '../../config'
 import { PrisonerNonAssociation } from '../../data/nonAssociationsApiClient'
+import MetricsService from '../../services/metricsService'
+import MetricsEvent from '../../data/metricsEvent'
 
 Reflect.deleteProperty(process.env, 'APPINSIGHTS_INSTRUMENTATIONKEY')
 
@@ -23,6 +25,7 @@ describe('move validation', () => {
   const nonAssociationsService = jest.mocked(new NonAssociationsService(undefined))
   const prisonerDetailsService = jest.mocked(new PrisonerDetailsService(undefined, undefined))
   const prisonerCellAllocationService = jest.mocked(new PrisonerCellAllocationService(undefined, undefined, undefined))
+  const metricsService = jest.mocked(new MetricsService(undefined))
 
   let req
   let res
@@ -266,6 +269,7 @@ describe('move validation', () => {
     prisonerDetailsService.getDetails = jest.fn()
     locationService.getLocation = jest.fn().mockResolvedValueOnce(cellLocationData)
     analyticsService.sendEvents = jest.fn().mockResolvedValue(Promise.resolve({}))
+    metricsService.trackEvent = jest.fn().mockResolvedValue(Promise.resolve({}))
     nonAssociationsService.getNonAssociations = jest.fn().mockResolvedValue({
       prisonerNumber: 'ABC123',
       firstName: 'Fred',
@@ -377,6 +381,7 @@ describe('move validation', () => {
       nonAssociationsService,
       prisonerDetailsService,
       prisonerCellAllocationService,
+      metricsService,
     })
   })
 
@@ -747,7 +752,7 @@ describe('move validation', () => {
     expect(res.redirect).toHaveBeenCalledWith(`/prisoner/${offenderNo}/cell-move/select-cell`)
   })
 
-  it('Raise ga event on cancel, containing the alert codes for all involed offenders', async () => {
+  it('Raise ga event and an app insights event on cancel, containing the alert codes for all involved offenders', async () => {
     prisonerCellAllocationService.getInmatesAtLocation.mockResolvedValue(occupants)
     prisonerDetailsService.getDetails
       .mockResolvedValueOnce(offenderDetails)
@@ -769,6 +774,10 @@ describe('move validation', () => {
         },
       },
     ])
+
+    expect(metricsService.trackEvent).toHaveBeenCalledWith(
+      MetricsEvent.CANCELLED_OR_CONSIDER_RISKS_EVENT('MDI', 'XEL,XGANG,VIP,HA,HA1,RTP,RLG,RLG', 'VIP,XGANG'),
+    )
 
     expect(res.redirect).toHaveBeenCalledWith(`/prisoner/${offenderNo}/cell-move/select-cell`)
   })

--- a/server/controllers/cellMove/considerRisks.ts
+++ b/server/controllers/cellMove/considerRisks.ts
@@ -13,6 +13,8 @@ import PrisonerCellAllocationService from '../../services/prisonerCellAllocation
 import logger from '../../../logger'
 import config from '../../config'
 import { NonAssociation } from '../../data/nonAssociationsApiClient'
+import MetricsService from '../../services/metricsService'
+import MetricsEvent from '../../data/metricsEvent'
 
 const activeCellMoveAlertsExcludingDisabled = alert =>
   !alert.expired && cellMoveAlertCodes.includes(alert.alertCode) && alert.alertCode !== 'PEEP'
@@ -25,6 +27,7 @@ type Params = {
   prisonerDetailsService: PrisonerDetailsService
   nonAssociationsService: NonAssociationsService
   prisonerCellAllocationService: PrisonerCellAllocationService
+  metricsService: MetricsService
 }
 
 export default ({
@@ -33,6 +36,7 @@ export default ({
   nonAssociationsService,
   prisonerDetailsService,
   prisonerCellAllocationService,
+  metricsService,
 }: Params) => {
   const getOccupantsDetails = async (context, offenders: string[]) =>
     Promise.all(offenders.map(offender => prisonerDetailsService.getDetails(context, offender, true)))
@@ -273,6 +277,14 @@ export default ({
         .catch(_reason => {
           logger.warn('Failed to send Google Analytics event')
         })
+
+      const event = MetricsEvent.CANCELLED_OR_CONSIDER_RISKS_EVENT(
+        currentOffenderDetails.agencyId,
+        offenderAlertCodes,
+        alertCodesAssociatedWithOccupants,
+      )
+
+      metricsService.trackEvent(event)
 
       return res.redirect(redirectUrl)
     } catch (error) {

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -8,7 +8,7 @@ import applicationInfoSupplier from '../applicationInfo'
 
 const applicationInfo = applicationInfoSupplier()
 initialiseAppInsights()
-buildAppInsightsClient(applicationInfo)
+const applicationInsightsClient = buildAppInsightsClient(applicationInfo)
 
 import HmppsAuthClient from './hmppsAuthClient'
 import ManageUsersApiClient from './manageUsersApiClient'
@@ -35,6 +35,7 @@ export const dataAccess = () => ({
   nonAssociationsApiClient: new NonAssociationsApiClient(),
   googleAnalyticsClient: new GoogleAnalyticsClient(),
   prisonerSearchApiClient: new PrisonerSearchApiClient(),
+  applicationInsightsClient,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
@@ -49,4 +50,5 @@ export {
   NonAssociationsApiClient,
   GoogleAnalyticsClient,
   PrisonerSearchApiClient,
+  applicationInsightsClient,
 }

--- a/server/data/metricsEvent.ts
+++ b/server/data/metricsEvent.ts
@@ -1,0 +1,36 @@
+export default class MetricsEvent {
+  properties: Record<string, string | number>
+
+  name: string
+
+  constructor(eventName: string, agencyId: string) {
+    this.name = eventName
+    this.properties = {
+      prisonCode: agencyId,
+    }
+  }
+
+  addProperties(properties: Record<string, string | number>) {
+    this.properties = { ...this.properties, ...properties }
+    return this
+  }
+
+  static CELL_MOVE_EVENT(agencyId: string, cellType: string) {
+    const event = new MetricsEvent('Cell move event', agencyId)
+    return event.addProperties({
+      cellType,
+    })
+  }
+
+  static CANCELLED_OR_CONSIDER_RISKS_EVENT(
+    agencyId: string,
+    offenderAlertCodes: string,
+    alertCodesAssociatedWithOccupants: string,
+  ) {
+    const event = new MetricsEvent('Cancelled or consider risks event', agencyId)
+    return event.addProperties({
+      offenderAlertCodes,
+      cellOccupantsAlertCodes: alertCodesAssociatedWithOccupants,
+    })
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -6,6 +6,7 @@ import PrisonerDetailsService from './prisonerDetailsService'
 import LocationService from './locationService'
 import NonAssociationsService from './nonAssociationsService'
 import AnalyticsService from './analyticsService'
+import MetricsService from './metricsService'
 
 export const services = () => {
   const {
@@ -18,6 +19,7 @@ export const services = () => {
     nonAssociationsApiClient,
     googleAnalyticsClient,
     prisonerSearchApiClient,
+    applicationInsightsClient,
   } = dataAccess()
 
   const userService = new UserService(manageUsersApiClient, prisonApiClient)
@@ -31,6 +33,7 @@ export const services = () => {
   const locationService = new LocationService(prisonApiClient, locationsInsidePrisonApiClient)
   const nonAssociationsService = new NonAssociationsService(nonAssociationsApiClient)
   const analyticsService = new AnalyticsService(googleAnalyticsClient)
+  const metricsService = new MetricsService(applicationInsightsClient)
 
   return {
     applicationInfo,
@@ -41,6 +44,7 @@ export const services = () => {
     locationService,
     nonAssociationsService,
     analyticsService,
+    metricsService,
   }
 }
 

--- a/server/services/metricsService.test.ts
+++ b/server/services/metricsService.test.ts
@@ -1,0 +1,16 @@
+import { TelemetryClient } from 'applicationinsights'
+import MetricsService from './metricsService'
+import MetricsEvent from '../data/metricsEvent'
+
+jest.mock('applicationinsights')
+
+describe('Metrics Service', () => {
+  const telemetryClient = new TelemetryClient()
+  const metricsService = new MetricsService(telemetryClient)
+
+  it('trackEvent', () => {
+    const event = new MetricsEvent('event-name', 'MDI')
+    metricsService.trackEvent(event)
+    expect(telemetryClient.trackEvent).toHaveBeenCalledWith(event)
+  })
+})

--- a/server/services/metricsService.ts
+++ b/server/services/metricsService.ts
@@ -1,0 +1,16 @@
+import { TelemetryClient } from 'applicationinsights'
+
+type Event = {
+  name: string
+  properties?: Record<string, string | number>
+}
+
+export default class MetricsService {
+  constructor(private readonly appInsightsClient: TelemetryClient) {}
+
+  trackEvent(event: Event) {
+    if (this.appInsightsClient) {
+      this.appInsightsClient.trackEvent(event)
+    }
+  }
+}


### PR DESCRIPTION
Replicating the Google analytics events in app insights