### PR TITLE
MAP-2541 add HMP Kilco allowlist group for dev only

### DIFF
--- a/helm_deploy/hmpps-change-someones-cell/values.yaml
+++ b/helm_deploy/hmpps-change-someones-cell/values.yaml
@@ -56,7 +56,8 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
+      - moj_cloud_platform
 
 generic-prometheus-alerts:
   targetApplication: hmpps-change-someones-cell

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,3 +24,8 @@ generic-service:
     ESTABLISHMENT_ROLL_URL: "https://prison-roll-count-dev.hmpps.service.justice.gov.uk"
     ALERTS_API_URL: "https://alerts-api-dev.hmpps.service.justice.gov.uk"
 
+  allowlist:
+    groups:
+      - digital_staff_and_mojo
+      - moj_cloud_platform
+      - kilco_uat

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,7 +23,8 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
+      - moj_cloud_platform
       - prisons
       - private_prisons
 


### PR DESCRIPTION
'Internal' allow list group now deprecated. 
Using digital_staff_and_mojo and  moj_cloud_platform instead, as per  hmpps-ip-allowlists github repo instructions