### PR TITLE
MAP-2668 update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11449,10 +11449,11 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
+      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
   },
   "overrides": {
     "@babel/helpers": "7.26.10",
-    "@babel/runtime": "7.26.10"
+    "@babel/runtime": "7.26.10",
+    "tmp": "0.2.4"
   }
 }


### PR DESCRIPTION
[MAP-2668](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?assignee=5cd29c554326200dc971eab7&selectedIssue=MAP-2668)

override tmp transitive dependency used by Cypress
