### PR TITLE
Mapb 449 csc investigate 500 error on cell move

### DIFF
--- a/server/controllers/cellMove/confirmCellMove.ts
+++ b/server/controllers/cellMove/confirmCellMove.ts
@@ -198,7 +198,7 @@ export default ({
       const { bookingId, prisonId } = await prisonerDetailsService.getPrisoner(systemClientToken, offenderNo)
       const agencyId = prisonId
       if (cellId === CSWAP) return await makeCSwap(req, res, { agencyId, bookingId, offenderNo })
-      logger.info(`Move offender ${offenderNo} with booking id of ${bookingId}`) 
+      logger.info(`Move offender ${offenderNo} with booking id of ${bookingId}`)
       return await makeCellMove(req, res, {
         cellId,
         bookingId,

--- a/server/controllers/cellMove/confirmCellMove.ts
+++ b/server/controllers/cellMove/confirmCellMove.ts
@@ -198,7 +198,7 @@ export default ({
       const { bookingId, prisonId } = await prisonerDetailsService.getPrisoner(systemClientToken, offenderNo)
       const agencyId = prisonId
       if (cellId === CSWAP) return await makeCSwap(req, res, { agencyId, bookingId, offenderNo })
-
+      logger.info(`Move offender ${offenderNo} with booking id of ${bookingId}`) 
       return await makeCellMove(req, res, {
         cellId,
         bookingId,

--- a/server/controllers/cellMove/confirmReceptionMove.ts
+++ b/server/controllers/cellMove/confirmReceptionMove.ts
@@ -92,8 +92,7 @@ export default ({ prisonerCellAllocationService, prisonerDetailsService }: Param
     }
 
     const { bookingId, prisonId } = await prisonerDetailsService.getPrisoner(systemClientToken, offenderNo)
-    logger.info(`Move offender ${offenderNo} with booking id of ${bookingId}`) 
-  
+    logger.info(`Move offender ${offenderNo} with booking id of ${bookingId}`)
     const receptionOccupancy = await prisonerCellAllocationService.getReceptionsWithCapacity(
       systemClientToken,
       prisonId,

--- a/server/controllers/cellMove/confirmReceptionMove.ts
+++ b/server/controllers/cellMove/confirmReceptionMove.ts
@@ -92,6 +92,8 @@ export default ({ prisonerCellAllocationService, prisonerDetailsService }: Param
     }
 
     const { bookingId, prisonId } = await prisonerDetailsService.getPrisoner(systemClientToken, offenderNo)
+    logger.info(`Move offender ${offenderNo} with booking id of ${bookingId}`) 
+  
     const receptionOccupancy = await prisonerCellAllocationService.getReceptionsWithCapacity(
       systemClientToken,
       prisonId,


### PR DESCRIPTION
Whereabouts-api sometimes returning a 500 error for calls to /cell/make-cell-move
error suggests CSC is posting bookingId as NULL even though it is required  by api

Added logging to determine if prisonerSearchApi is returning Null value for bookingId which CSC then posts to whereaboutsApi